### PR TITLE
Standardize lote view components

### DIFF
--- a/my-project/src/components/app/lotes/loteselector.tsx
+++ b/my-project/src/components/app/lotes/loteselector.tsx
@@ -24,7 +24,11 @@ interface LoteSelectorProps {
   loading: boolean;
   onSelect: (lote: Lote) => void;
   onSelectNone: () => void;
-  onCreate: (nombre: string) => void;
+  onCreate?: (nombre: string) => void;
+  title?: string;
+  infoLabel?: string;
+  actionLabel?: string;
+  description?: string;
 }
 
 export function LoteSelector({
@@ -34,6 +38,10 @@ export function LoteSelector({
   onSelect,
   onSelectNone,
   onCreate,
+  title = "Lote Activo",
+  infoLabel = "Trabajando en:",
+  actionLabel = "Cambiar",
+  description,
 }: LoteSelectorProps) {
   const [open, setOpen] = React.useState(false);
   const [showNewForm, setShowNewForm] = React.useState(false);
@@ -56,31 +64,37 @@ export function LoteSelector({
     <div className="w-full">
       <div className="flex flex-col space-y-2">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Lote Activo</h2>
-          <Button
-            variant="outline"
-            onClick={() => {
-              setShowNewForm(true);
-              setOpen(true);
-            }}
-          >
-            Crear Nuevo Lote
-          </Button>
+          <div>
+            <h2 className="text-lg font-semibold">{title}</h2>
+            {description && (
+              <p className="text-sm font-bold text-red-600">{description}</p>
+            )}
+          </div>
+          {onCreate && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowNewForm(true);
+                setOpen(true);
+              }}
+            >
+              Crear Nuevo Lote
+            </Button>
+          )}
         </div>
         <div className="bg-white rounded-lg border p-4 flex justify-between items-center">
           <div>
-            <p className="text-sm text-gray-500">Trabajando en:</p>
+            <p className="text-sm text-gray-500">{infoLabel}</p>
             <p className="text-xl font-medium">
               {selectedLote?.nombre || "Ningún lote seleccionado"}
             </p>
             {selectedLote?.fechaCreacion && (
               <p className="text-xs text-gray-400">
-                Creado:{" "}
-                {new Date(selectedLote.fechaCreacion).toLocaleDateString()}
+                Creado: {new Date(selectedLote.fechaCreacion).toLocaleDateString()}
               </p>
             )}
           </div>
-          <Button onClick={() => setOpen(true)}>Cambiar</Button>
+          <Button onClick={() => setOpen(true)}>{actionLabel}</Button>
         </div>
       </div>
 
@@ -88,11 +102,11 @@ export function LoteSelector({
         <DialogContent className="sm:max-w-md md:max-w-lg">
           <DialogHeader>
             <DialogTitle className="text-xl">
-              {showNewForm ? "Crear Nuevo Lote" : "Seleccionar Lote"}
+              {onCreate && showNewForm ? "Crear Nuevo Lote" : "Seleccionar Lote"}
             </DialogTitle>
           </DialogHeader>
 
-          {showNewForm ? (
+          {onCreate && showNewForm ? (
             <div className="space-y-4 py-4">
               <Input
                 placeholder="Nombre del nuevo lote"
@@ -106,7 +120,7 @@ export function LoteSelector({
                 </Button>
                 <Button
                   onClick={() => {
-                    onCreate(newName.trim());
+                    onCreate?.(newName.trim());
                     setNewName("");
                     setShowNewForm(false);
                     setOpen(false);

--- a/my-project/src/components/app/lotes/resumenloteselector.tsx
+++ b/my-project/src/components/app/lotes/resumenloteselector.tsx
@@ -1,22 +1,7 @@
 "use client";
 
-import { Check, Search } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import React from "react";
-
-export interface Lote {
-  id: string;
-  nombre: string;
-  fechaCreacion?: string;
-}
+import { LoteSelector, type Lote } from "./loteselector";
 
 interface ResumenLoteSelectorProps {
   lotes: Lote[];
@@ -26,132 +11,15 @@ interface ResumenLoteSelectorProps {
   onSelectNone: () => void;
 }
 
-export function ResumenLoteSelector({
-  lotes,
-  selectedLote,
-  loading,
-  onSelect,
-  onSelectNone,
-}: ResumenLoteSelectorProps) {
-  const [open, setOpen] = React.useState(false);
-  const [search, setSearch] = React.useState("");
-
-  const filtered = lotes.filter((l) =>
-    l.nombre.toLowerCase().includes(search.toLowerCase())
-  );
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-24">
-        Cargando lotes…
-      </div>
-    );
-  }
-
+export function ResumenLoteSelector(props: ResumenLoteSelectorProps) {
   return (
-    <div className="w-full">
-      <div className="flex flex-col space-y-2">
-        <div className=" items-center justify-between">
-          <h2 className="text-lg font-semibold">Lote seleccionado</h2>
-          <h3 className="text-sm font-bold text-red-600">
-            *Recuerda que acá solo estás viendo los datos, no cambiando el lote
-            activo
-          </h3>
-        </div>
-        <div className="bg-white rounded-lg border p-4 flex justify-between items-center">
-          <div>
-            <p className="text-sm text-gray-500">Datos de:</p>
-            <p className="text-xl font-medium">
-              {selectedLote?.nombre || "Ningún lote seleccionado"}
-            </p>
-            {selectedLote?.fechaCreacion && (
-              <p className="text-xs text-gray-400">
-                Creado:{" "}
-                {new Date(selectedLote.fechaCreacion).toLocaleDateString()}
-              </p>
-            )}
-          </div>
-          <Button onClick={() => setOpen(true)}>Ver otro lote</Button>
-        </div>
-      </div>
-
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-md md:max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="text-xl">Seleccionar Lote</DialogTitle>
-          </DialogHeader>
-
-          <div className="space-y-4">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" />
-              <Input
-                placeholder="Buscar lotes..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="pl-8"
-                autoFocus
-              />
-            </div>
-            <ScrollArea className="h-72 rounded-md border">
-              <div className="p-2 space-y-1">
-                <button
-                  onClick={() => {
-                    onSelectNone();
-                    setOpen(false);
-                  }}
-                  className={`w-full flex items-center justify-between p-2 rounded-md text-left ${
-                    selectedLote === null
-                      ? "bg-primary-50 text-primary-600"
-                      : "hover:bg-gray-100"
-                  }`}
-                >
-                  <div className="font-medium">Ninguno</div>
-                  {selectedLote === null && (
-                    <Check className="h-4 w-4 text-primary-600" />
-                  )}
-                </button>
-
-                {filtered.length > 0 ? (
-                  filtered.map((lote) => (
-                    <button
-                      key={lote.id}
-                      onClick={() => {
-                        onSelect(lote);
-                        setOpen(false);
-                      }}
-                      className={`w-full flex items-center justify-between p-2 rounded-md text-left ${
-                        selectedLote?.id === lote.id
-                          ? "bg-primary-50 text-primary-600"
-                          : "hover:bg-gray-100"
-                      }`}
-                    >
-                      <div>
-                        <div className="font-medium">{lote.nombre}</div>
-                        {lote.fechaCreacion && (
-                          <div className="text-xs text-gray-500">
-                            Creado:{" "}
-                            {new Date(lote.fechaCreacion).toLocaleDateString()}
-                          </div>
-                        )}
-                      </div>
-                      {selectedLote?.id === lote.id && (
-                        <Check className="h-4 w-4 text-primary-600" />
-                      )}
-                    </button>
-                  ))
-                ) : (
-                  <div className="p-4 text-center text-gray-500">
-                    No se encontraron lotes
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-            <div className="flex justify-end">
-              <Button onClick={() => setOpen(false)}>Cerrar</Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </div>
+    <LoteSelector
+      {...props}
+      onCreate={undefined}
+      title="Lote seleccionado"
+      infoLabel="Datos de:"
+      actionLabel="Ver otro lote"
+      description="*Recuerda que acá solo estás viendo los datos, no cambiando el lote activo"
+    />
   );
 }

--- a/my-project/src/components/app/lotes/summarylote.tsx
+++ b/my-project/src/components/app/lotes/summarylote.tsx
@@ -2,15 +2,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-
-interface Summary {
-  dispositivo: string;
-  countIn: number;
-  countOut: number;
-  lastTimestamp: string | null;
-  servicioId: string;
-}
+import { ResumenLote, type Summary } from "./resumenlote";
 
 interface SummaryLoteProps {
   loteId: string;
@@ -50,12 +42,6 @@ export function SummaryLote({ loteId }: SummaryLoteProps) {
       });
   }, [loteId]);
 
-  // Calcular el total de bulbos de todo el lote (suma de countIn + countOut por dispositivo)
-  const totalBulbos = summaries.reduce(
-    (acc, row) => acc + (row.countIn + row.countOut),
-    0
-  );
-
   if (!loteId) {
     return (
       <p className="text-center text-gray-500">
@@ -64,103 +50,7 @@ export function SummaryLote({ loteId }: SummaryLoteProps) {
     );
   }
 
-  if (loading) {
-    return <p className="text-center">Cargando resumen…</p>;
-  }
-
-  if (error) {
-    return <p className="text-center text-red-500">{error}</p>;
-  }
-
-  if (summaries.length === 0) {
-    return (
-      <p className="text-center text-gray-500">
-        No se encontró información para este lote.
-      </p>
-    );
-  }
-
   return (
-    <Card className="w-full bg-white shadow rounded-lg">
-      <CardHeader>
-        <CardTitle className="text-lg font-semibold">
-          Resumen por Dispositivo
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div>
-          <p className="text-xl font-bold">
-            Total Bulbos Lote:{" "}
-            <span className="text-green-600">{totalBulbos}</span>
-          </p>
-        </div>
-
-        <div className="w-full overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Dispositivo
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Ingresos
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Último Conteo
-                </th>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  Servicio
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {summaries.map((row) => {
-                const fechaLocal = row.lastTimestamp
-                  ? new Date(row.lastTimestamp).toLocaleString("es-CL", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })
-                  : "—";
-
-                // Ingresos = countIn + countOut
-                const ingresos = row.countIn + row.countOut;
-
-                return (
-                  <tr key={row.dispositivo}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-                      {row.dispositivo}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-900 font-medium">
-                      {ingresos}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-700">
-                      {fechaLocal}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-700">
-                      {row.servicioId || "—"}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </CardContent>
-    </Card>
+    <ResumenLote summary={summaries} loading={loading} error={error} />
   );
 }


### PR DESCRIPTION
## Summary
- allow customization of `LoteSelector`
- refactor `ResumenLoteSelector` to reuse `LoteSelector`
- simplify `SummaryLote` using `ResumenLote`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426a6a90708330bd164f6f326f5d10