### PR TITLE
Add company summary API and dashboard overview

### DIFF
--- a/my-project/src/app/api/companies/summary/route.ts
+++ b/my-project/src/app/api/companies/summary/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { connectDb } from "@/lib/mongodb";
+import { Lote } from "@/models/lotes";
+import { LoteActivity } from "@/models/loteactivity";
+import { Conteo } from "@/models/conteo";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const empresaId = searchParams.get("empresaId");
+  const daysParam = searchParams.get("days");
+  const days = daysParam ? parseInt(daysParam, 10) : null;
+
+  if (!empresaId) {
+    return NextResponse.json({ error: "empresaId is required" }, { status: 400 });
+  }
+
+  await connectDb();
+
+  const lotes = await Lote.find({ empresaId }, { _id: 1 }).lean();
+  if (lotes.length === 0) {
+    return NextResponse.json({ total: 0, perHour: [] });
+  }
+
+  const loteIds = lotes.map((l) => l._id);
+  const activities = await LoteActivity.find({ loteId: { $in: loteIds } }).lean();
+  if (activities.length === 0) {
+    return NextResponse.json({ total: 0, perHour: [] });
+  }
+
+  const now = new Date();
+  const startLimit = days ? new Date(now.getTime() - days * 24 * 60 * 60 * 1000) : new Date(0);
+
+  const orConds = activities.map(({ startTime, endTime }) => ({
+    timestamp: {
+      $gte: startTime > startLimit ? startTime : startLimit,
+      $lte: endTime ?? now,
+    },
+  }));
+
+  const matchStage = { $or: orConds };
+
+  const perHour = await Conteo.aggregate([
+    { $match: matchStage },
+    {
+      $group: {
+        _id: {
+          year: { $year: "$timestamp" },
+          month: { $month: "$timestamp" },
+          day: { $dayOfMonth: "$timestamp" },
+          hour: { $hour: "$timestamp" },
+        },
+        total: { $sum: { $add: ["$countIn", "$countOut"] } },
+      },
+    },
+    {
+      $sort: {
+        "_id.year": 1,
+        "_id.month": 1,
+        "_id.day": 1,
+        "_id.hour": 1,
+      },
+    },
+  ]);
+
+  const total = perHour.reduce((sum, r) => sum + r.total, 0);
+
+  return NextResponse.json({ total, perHour });
+}

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -6,6 +6,22 @@ import { AuthenticationContext } from "@/app/context/AuthContext";
 import { Lote } from "@/components/app/lotes/loteselector";
 import { ResumenLoteSelector } from "@/components/app/lotes/resumenloteselector";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import * as XLSX from "xlsx";
 import { Summary, ResumenLote } from "@/components/app/lotes/resumenlote";
@@ -37,10 +53,13 @@ export default function Dashboard() {
   const [dataLoading, setDataLoading] = useState(false);
   const [errorRecords, setErrorRecords] = useState<string | null>(null);
 
-  // Datos totales de la empresa
-  const [totalRecords, setTotalRecords] = useState<ConteoRecord[]>([]);
-  const [loadingTotal, setLoadingTotal] = useState(false);
-  const [errorTotal, setErrorTotal] = useState<string | null>(null);
+
+  // Datos agregados por empresa
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [activeLote, setActiveLote] = useState<{ id: string; nombre: string } | null>(null);
+  const [chartData, setChartData] = useState<{ time: string; total: number }[]>([]);
+  const [period, setPeriod] = useState<string>("1");
+  const [loadingCompanyData, setLoadingCompanyData] = useState(false);
 
   // ============== Funciones de carga (fetch) ==============
 
@@ -128,18 +147,47 @@ export default function Dashboard() {
     }
   }, [selectedLote, fetchRecordsData]);
 
-  // 6) Carga datos totales de la empresa
+
+  // 6b) Datos agregados y gráfico por empresa
+  const fetchCompanyData = useCallback(() => {
+    if (!data) return;
+    setLoadingCompanyData(true);
+    fetch(`/api/companies/summary?empresaId=${data.empresaId}&days=${period}`)
+      .then((res) => res.json())
+      .then((obj) => {
+        setTotalCount(obj.total || 0);
+        const mapped = Array.isArray(obj.perHour)
+          ? obj.perHour.map((p: any) => ({
+              time: new Date(
+                p._id.year,
+                p._id.month - 1,
+                p._id.day,
+                p._id.hour
+              ).toLocaleString("es-CL", {
+                hour: "2-digit",
+                day: "2-digit",
+                month: "2-digit",
+              }),
+              total: p.total,
+            }))
+          : [];
+        setChartData(mapped);
+      })
+      .catch((err) => console.error(err))
+      .finally(() => setLoadingCompanyData(false));
+  }, [data, period]);
+
+  useEffect(() => {
+    fetchCompanyData();
+  }, [fetchCompanyData]);
+
+  // 6c) Lote activo
   useEffect(() => {
     if (!data) return;
-    setLoadingTotal(true);
-    fetch(`/api/conteos?empresaId=${data.empresaId}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Error al cargar datos totales");
-        return res.json();
-      })
-      .then((arr: ConteoRecord[]) => setTotalRecords(arr))
-      .catch((err) => setErrorTotal(err.message))
-      .finally(() => setLoadingTotal(false));
+    fetch(`/api/lotes/activity/last?empresaId=${data.empresaId}`)
+      .then((res) => res.json())
+      .then((res) => setActiveLote(res))
+      .catch((err) => console.error(err));
   }, [data]);
 
   // 7) Función para exportar Excel de datos por lote
@@ -183,45 +231,43 @@ export default function Dashboard() {
         {/* ------------------------------------------------------ */}
         {/* DATOS TOTALES */}
         <TabsContent value="datosTotales">
-          {loadingTotal ? (
-            <p>Cargando datos totales…</p>
-          ) : errorTotal ? (
-            <p className="text-red-600">{errorTotal}</p>
+          {loadingCompanyData ? (
+            <p>Cargando datos…</p>
           ) : (
             <Card>
               <CardHeader>
                 <CardTitle>Datos Totales</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="overflow-x-auto">
-                  <table className="min-w-full table-auto divide-y divide-gray-200">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                          Hora
-                        </th>
-                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                          Conteo
-                        </th>
-                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                          Dispositivo
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-gray-200">
-                      {totalRecords.map((rec) => (
-                        <tr key={rec._id}>
-                          <td className="px-4 py-2">
-                            {new Date(rec.timestamp).toLocaleString("es-CL")}
-                          </td>
-                          <td className="px-4 py-2">
-                            {rec.count_in + rec.count_out}
-                          </td>
-                          <td className="px-4 py-2">{rec.dispositivo}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                <p className="text-lg font-semibold">
+                  Total conteos: {totalCount}
+                </p>
+                <p className="mt-2">
+                  Lote activo: {activeLote ? activeLote.nombre : "Ninguno"}
+                </p>
+                <div className="mt-4 mb-2">
+                  <Select value={period} onValueChange={(v) => setPeriod(v)}>
+                    <SelectTrigger className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="1">Hoy</SelectItem>
+                      <SelectItem value="3">Últimos 3 días</SelectItem>
+                      <SelectItem value="7">Última semana</SelectItem>
+                      <SelectItem value="30">Último mes</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="w-full h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis dataKey="time" />
+                      <YAxis />
+                      <Tooltip />
+                      <Line type="monotone" dataKey="total" stroke="#8884d8" />
+                    </LineChart>
+                  </ResponsiveContainer>
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- create `companies/summary` API to get total counts and hourly data per company
- show total count, active lot and production chart on the dashboard

## Testing
- `npx tsc -p my-project/tsconfig.json` *(fails: Could not find types for modules)*

------
https://chatgpt.com/codex/tasks/task_e_68426b391f5483309a4867fdeb597a26