### PR TITLE
Use shared lote summary component

### DIFF
--- a/my-project/src/app/app/lotes/page.tsx
+++ b/my-project/src/app/app/lotes/page.tsx
@@ -4,7 +4,7 @@
 import { useContext, useState, useEffect } from "react";
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import { LoteSelector, Lote } from "@/components/app/lotes/loteselector";
-import { SummaryLote } from "@/components/app/lotes/summarylote";
+import { LoteTabs } from "@/components/app/lotes/lotetabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -127,46 +127,7 @@ export default function Dashboard() {
           </CardContent>
         </Card>
 
-        <Tabs defaultValue="resumen">
-          <TabsList className="grid grid-cols-3 mb-4">
-            <TabsTrigger value="resumen">Resumen</TabsTrigger>
-            <TabsTrigger value="datos">Datos</TabsTrigger>
-            <TabsTrigger value="graficos">Gráficos</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="resumen">
-            {selectedLote ? (
-              <SummaryLote loteId={loteId} />
-            ) : (
-              <div className="text-center text-gray-500">
-                Selecciona un lote para ver su resumen.
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="datos">
-            {/* Aquí iría tu contenido de “Datos” */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Datos del Lote</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p>Implementa aquí tu vista de datos.</p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="graficos">
-            <Card>
-              <CardHeader>
-                <CardTitle>Gráficos del Lote</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p>Aquí se generarán los gráficos de conteos del lote.</p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+        <LoteTabs loteId={loteId} />
       </div>
     </div>
   );

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -1,14 +1,13 @@
 // app/dashboard/page.tsx
 
 "use client";
-import React, { useContext, useState, useEffect, useCallback } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import { Lote } from "@/components/app/lotes/loteselector";
 import { ResumenLoteSelector } from "@/components/app/lotes/resumenloteselector";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import * as XLSX from "xlsx";
-import { Summary, ResumenLote } from "@/components/app/lotes/resumenlote";
+import { LoteTabs } from "@/components/app/lotes/lotetabs";
 // Define aquí la forma de cada registro de conteo
 interface ConteoRecord {
   _id: string;
@@ -27,15 +26,6 @@ export default function Dashboard() {
   const [loadingLotes, setLoadingLotes] = useState(false);
   const [selectedLote, setSelectedLote] = useState<Lote | null>(null);
 
-  // Resumen por lote (ahora Summary[] | null)
-  const [summary, setSummary] = useState<Summary[] | null>(null);
-  const [loadingSummary, setLoadingSummary] = useState(false);
-  const [errorSummary, setErrorSummary] = useState<string | null>(null);
-
-  // Datos por lote
-  const [records, setRecords] = useState<ConteoRecord[]>([]);
-  const [dataLoading, setDataLoading] = useState(false);
-  const [errorRecords, setErrorRecords] = useState<string | null>(null);
 
   // Datos totales de la empresa
   const [totalRecords, setTotalRecords] = useState<ConteoRecord[]>([]);
@@ -55,80 +45,7 @@ export default function Dashboard() {
       .finally(() => setLoadingLotes(false));
   }, [data]);
 
-  // 2) Función para recargar el resumen de un lote (Summary[])
-  const fetchSummaryData = useCallback(() => {
-    if (!selectedLote) {
-      setSummary(null);
-      setErrorSummary(null);
-      return;
-    }
-
-    setLoadingSummary(true);
-    setErrorSummary(null);
-
-    fetch(`/api/lotes/summary?loteId=${selectedLote.id}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Error al cargar resumen");
-        return res.json();
-      })
-      .then((arr: Summary[]) => {
-        setSummary(arr);
-      })
-      .catch((err) => setErrorSummary(err.message))
-      .finally(() => setLoadingSummary(false));
-  }, [selectedLote]);
-
-  // 3) useEffect para invocar fetchSummaryData cuando cambie selectedLote
-  useEffect(() => {
-    // cada vez que cambie de lote, cargo el nuevo resumen
-    if (selectedLote) {
-      fetchSummaryData();
-    } else {
-      setSummary(null);
-      setErrorSummary(null);
-    }
-  }, [selectedLote, fetchSummaryData]);
-
-  // 4) Función para recargar los registros de conteo (ConteoRecord[])
-  const fetchRecordsData = useCallback(() => {
-    if (!selectedLote || !data) {
-      setRecords([]);
-      return;
-    }
-
-    setDataLoading(true);
-    setErrorRecords(null);
-
-    fetch(`/api/conteos?empresaId=${data.empresaId}&loteId=${selectedLote.id}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Error al cargar los registros");
-        return res.json();
-      })
-      .then((arr: ConteoRecord[]) => {
-        // Ordenamos de más reciente a más antiguo según el campo timestamp
-        const sortedArr = arr.sort((a, b) => {
-          return (
-            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-          );
-        });
-        setRecords(sortedArr);
-      })
-      .catch((err) => setErrorRecords(err.message))
-      .finally(() => setDataLoading(false));
-  }, [selectedLote, data]);
-
-  // 5) useEffect para invocar fetchRecordsData cuando cambie selectedLote
-  useEffect(() => {
-    // cada vez que cambie de lote, cargo los registros
-    if (selectedLote) {
-      fetchRecordsData();
-    } else {
-      setRecords([]);
-      setErrorRecords(null);
-    }
-  }, [selectedLote, fetchRecordsData]);
-
-  // 6) Carga datos totales de la empresa
+  // 2) Carga datos totales de la empresa
   useEffect(() => {
     if (!data) return;
     setLoadingTotal(true);
@@ -142,28 +59,6 @@ export default function Dashboard() {
       .finally(() => setLoadingTotal(false));
   }, [data]);
 
-  // 7) Función para exportar Excel de datos por lote
-  const downloadExcel = () => {
-    if (records.length === 0) {
-      alert("No hay datos para exportar");
-      return;
-    }
-    const sheetData = records.map((r) => ({
-      Hora: new Date(r.timestamp).toLocaleString("es-CL"),
-      Conteo: r.count_in + r.count_out,
-      Dispositivo: r.dispositivo,
-    }));
-    const ws = XLSX.utils.json_to_sheet(sheetData);
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, "Conteos");
-    XLSX.writeFile(
-      wb,
-      `conteos_${selectedLote?.nombre || "sin_lote"}_${new Date()
-        .toISOString()
-        .slice(0, 19)
-        .replace(/[:T]/g, "-")}.xlsx`
-    );
-  };
 
   // ============== Renderizado ==============
   if (authLoading) return <div>Cargando…</div>;
@@ -247,113 +142,7 @@ export default function Dashboard() {
             </CardContent>
           </Card>
 
-          {/* Sub-pestañas: Resumen y Datos */}
-          <Tabs defaultValue="resumen">
-            <TabsList className="grid grid-cols-2 mb-4">
-              <TabsTrigger value="resumen">Resumen</TabsTrigger>
-              <TabsTrigger value="datos">Datos</TabsTrigger>
-            </TabsList>
-
-            {/* -------------------------------------------------- */}
-            {/* Resumen por Lote */}
-            <TabsContent value="resumen">
-              {!selectedLote ? (
-                <p className="text-center py-4">
-                  Selecciona primero un lote para ver el resumen.
-                </p>
-              ) : (
-                <>
-                  <div className="flex justify-end mb-2">
-                    <button
-                      onClick={fetchSummaryData}
-                      className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                    >
-                      🔄 Refrescar Resumen
-                    </button>
-                  </div>
-                  <ResumenLote
-                    summary={summary}
-                    loading={loadingSummary}
-                    error={errorSummary}
-                  />
-                </>
-              )}
-            </TabsContent>
-
-            {/* -------------------------------------------------- */}
-            {/* Datos por Lote */}
-            <TabsContent value="datos">
-              {!selectedLote ? (
-                <p className="text-center py-4">
-                  Selecciona primero un lote para ver los datos.
-                </p>
-              ) : (
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Datos de Conteos</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex justify-between mb-4">
-                      <div>Total registros: {records.length}</div>
-                      <div className="flex space-x-2">
-                        <button
-                          onClick={fetchRecordsData}
-                          className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                        >
-                          🔄 Refrescar Datos
-                        </button>
-                        <button
-                          onClick={downloadExcel}
-                          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-                        >
-                          Descargar Excel
-                        </button>
-                      </div>
-                    </div>
-
-                    {dataLoading ? (
-                      <p>Cargando datos…</p>
-                    ) : errorRecords ? (
-                      <p className="text-red-600">{errorRecords}</p>
-                    ) : (
-                      <div className="overflow-x-auto">
-                        <table className="min-w-full table-auto divide-y divide-gray-200">
-                          <thead className="bg-gray-50">
-                            <tr>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Hora
-                              </th>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Conteo
-                              </th>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Dispositivo
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody className="bg-white divide-y divide-gray-200">
-                            {records.map((r) => (
-                              <tr key={r._id}>
-                                <td className="px-4 py-2">
-                                  {new Date(r.timestamp).toLocaleString(
-                                    "es-CL"
-                                  )}
-                                </td>
-                                <td className="px-4 py-2">
-                                  {r.count_in + r.count_out}
-                                </td>
-                                <td className="px-4 py-2">{r.dispositivo}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              )}
-            </TabsContent>
-          </Tabs>
+          <LoteTabs loteId={selectedLote?.id ?? null} />
         </TabsContent>
       </Tabs>
     </div>

--- a/my-project/src/components/app/lotes/lotetabs.tsx
+++ b/my-project/src/components/app/lotes/lotetabs.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { AuthenticationContext } from "@/app/context/AuthContext";
+import { SummaryLote } from "./summarylote";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import * as XLSX from "xlsx";
+
+interface ConteoRecord {
+  _id: string;
+  timestamp: string;
+  count_in: number;
+  count_out: number;
+  dispositivo: string;
+}
+
+interface LoteTabsProps {
+  loteId: string | null;
+}
+
+export function LoteTabs({ loteId }: LoteTabsProps) {
+  const { data } = useContext(AuthenticationContext);
+
+  const [records, setRecords] = useState<ConteoRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRecordsData = useCallback(() => {
+    if (!loteId || !data) {
+      setRecords([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/conteos?empresaId=${data.empresaId}&loteId=${loteId}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Error al cargar los registros");
+        return res.json();
+      })
+      .then((arr: ConteoRecord[]) => {
+        const sorted = arr.sort(
+          (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+        );
+        setRecords(sorted);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [loteId, data]);
+
+  useEffect(() => {
+    fetchRecordsData();
+  }, [fetchRecordsData]);
+
+  const downloadExcel = () => {
+    if (records.length === 0) {
+      alert("No hay datos para exportar");
+      return;
+    }
+    const sheetData = records.map((r) => ({
+      Hora: new Date(r.timestamp).toLocaleString("es-CL"),
+      Conteo: r.count_in + r.count_out,
+      Dispositivo: r.dispositivo,
+    }));
+    const ws = XLSX.utils.json_to_sheet(sheetData);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Conteos");
+    XLSX.writeFile(
+      wb,
+      `conteos_${loteId || "sin_lote"}_${new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace(/[:T]/g, "-")}.xlsx`
+    );
+  };
+
+  if (!loteId) {
+    return (
+      <p className="text-center py-4">
+        Selecciona primero un lote para ver el resumen.
+      </p>
+    );
+  }
+
+  return (
+    <Tabs defaultValue="resumen">
+      <TabsList className="grid grid-cols-2 mb-4">
+        <TabsTrigger value="resumen">Resumen</TabsTrigger>
+        <TabsTrigger value="datos">Datos</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="resumen">
+        <SummaryLote loteId={loteId} />
+      </TabsContent>
+
+      <TabsContent value="datos">
+        <Card>
+          <CardHeader>
+            <CardTitle>Datos de Conteos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex justify-between mb-4">
+              <div>Total registros: {records.length}</div>
+              <div className="flex space-x-2">
+                <button
+                  onClick={fetchRecordsData}
+                  className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                >
+                  🔄 Refrescar Datos
+                </button>
+                <button
+                  onClick={downloadExcel}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                  Descargar Excel
+                </button>
+              </div>
+            </div>
+
+            {loading ? (
+              <p>Cargando datos…</p>
+            ) : error ? (
+              <p className="text-red-600">{error}</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full table-auto divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                        Hora
+                      </th>
+                      <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                        Conteo
+                      </th>
+                      <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                        Dispositivo
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {records.map((r) => (
+                      <tr key={r._id}>
+                        <td className="px-4 py-2">
+                          {new Date(r.timestamp).toLocaleString("es-CL")}
+                        </td>
+                        <td className="px-4 py-2">{r.count_in + r.count_out}</td>
+                        <td className="px-4 py-2">{r.dispositivo}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+}


### PR DESCRIPTION
## Summary
- add `LoteTabs` reusable component to show resumen/datos tabs
- reuse `LoteTabs` in home page and lotes page
- remove old summary/data logic from home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426ff81714833099eab63fd1f2685d