### PR TITLE
Unify lote views with reusable tabs

### DIFF
--- a/my-project/src/app/app/lotes/page.tsx
+++ b/my-project/src/app/app/lotes/page.tsx
@@ -4,9 +4,8 @@
 import { useContext, useState, useEffect } from "react";
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import { LoteSelector, Lote } from "@/components/app/lotes/loteselector";
-import { SummaryLote } from "@/components/app/lotes/summarylote";
+import { LoteDataTabs } from "@/components/app/lotes/lotedatatabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export default function Dashboard() {
   const { data, loading: authLoading } = useContext(AuthenticationContext);
@@ -104,7 +103,6 @@ export default function Dashboard() {
     );
   }
 
-  const loteId = selectedLote?.id ?? "";
 
   return (
     <div className="w-full max-w-6xl mx-auto p-6">
@@ -126,47 +124,7 @@ export default function Dashboard() {
             />
           </CardContent>
         </Card>
-
-        <Tabs defaultValue="resumen">
-          <TabsList className="grid grid-cols-3 mb-4">
-            <TabsTrigger value="resumen">Resumen</TabsTrigger>
-            <TabsTrigger value="datos">Datos</TabsTrigger>
-            <TabsTrigger value="graficos">Gráficos</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="resumen">
-            {selectedLote ? (
-              <SummaryLote loteId={loteId} />
-            ) : (
-              <div className="text-center text-gray-500">
-                Selecciona un lote para ver su resumen.
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="datos">
-            {/* Aquí iría tu contenido de “Datos” */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Datos del Lote</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p>Implementa aquí tu vista de datos.</p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="graficos">
-            <Card>
-              <CardHeader>
-                <CardTitle>Gráficos del Lote</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p>Aquí se generarán los gráficos de conteos del lote.</p>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+        <LoteDataTabs empresaId={data.empresaId} lote={selectedLote} />
       </div>
     </div>
   );

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -1,20 +1,13 @@
 // app/dashboard/page.tsx
 
 "use client";
-import React, {
-  useContext,
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-} from "react";
+import React, { useContext, useState, useEffect, useMemo } from "react";
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import { Lote } from "@/components/app/lotes/loteselector";
 import { ResumenLoteSelector } from "@/components/app/lotes/resumenloteselector";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import * as XLSX from "xlsx";
-import { Summary, ResumenLote } from "@/components/app/lotes/resumenlote";
+import { LoteDataTabs } from "@/components/app/lotes/lotedatatabs";
 import {
   LineChart,
   Line,
@@ -49,15 +42,6 @@ export default function Dashboard() {
   const [loadingLotes, setLoadingLotes] = useState(false);
   const [selectedLote, setSelectedLote] = useState<Lote | null>(null);
 
-  // Resumen por lote (ahora Summary[] | null)
-  const [summary, setSummary] = useState<Summary[] | null>(null);
-  const [loadingSummary, setLoadingSummary] = useState(false);
-  const [errorSummary, setErrorSummary] = useState<string | null>(null);
-
-  // Datos por lote
-  const [records, setRecords] = useState<ConteoRecord[]>([]);
-  const [dataLoading, setDataLoading] = useState(false);
-  const [errorRecords, setErrorRecords] = useState<string | null>(null);
 
   // Datos totales de la empresa
   const [totalRecords, setTotalRecords] = useState<ConteoRecord[]>([]);
@@ -92,78 +76,6 @@ export default function Dashboard() {
       .catch(() => setActiveLote(null));
   }, [data]);
 
-  // 2) Función para recargar el resumen de un lote (Summary[])
-  const fetchSummaryData = useCallback(() => {
-    if (!selectedLote) {
-      setSummary(null);
-      setErrorSummary(null);
-      return;
-    }
-
-    setLoadingSummary(true);
-    setErrorSummary(null);
-
-    fetch(`/api/lotes/summary?loteId=${selectedLote.id}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Error al cargar resumen");
-        return res.json();
-      })
-      .then((arr: Summary[]) => {
-        setSummary(arr);
-      })
-      .catch((err) => setErrorSummary(err.message))
-      .finally(() => setLoadingSummary(false));
-  }, [selectedLote]);
-
-  // 3) useEffect para invocar fetchSummaryData cuando cambie selectedLote
-  useEffect(() => {
-    // cada vez que cambie de lote, cargo el nuevo resumen
-    if (selectedLote) {
-      fetchSummaryData();
-    } else {
-      setSummary(null);
-      setErrorSummary(null);
-    }
-  }, [selectedLote, fetchSummaryData]);
-
-  // 4) Función para recargar los registros de conteo (ConteoRecord[])
-  const fetchRecordsData = useCallback(() => {
-    if (!selectedLote || !data) {
-      setRecords([]);
-      return;
-    }
-
-    setDataLoading(true);
-    setErrorRecords(null);
-
-    fetch(`/api/conteos?empresaId=${data.empresaId}&loteId=${selectedLote.id}`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Error al cargar los registros");
-        return res.json();
-      })
-      .then((arr: ConteoRecord[]) => {
-        // Ordenamos de más reciente a más antiguo según el campo timestamp
-        const sortedArr = arr.sort((a, b) => {
-          return (
-            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-          );
-        });
-        setRecords(sortedArr);
-      })
-      .catch((err) => setErrorRecords(err.message))
-      .finally(() => setDataLoading(false));
-  }, [selectedLote, data]);
-
-  // 5) useEffect para invocar fetchRecordsData cuando cambie selectedLote
-  useEffect(() => {
-    // cada vez que cambie de lote, cargo los registros
-    if (selectedLote) {
-      fetchRecordsData();
-    } else {
-      setRecords([]);
-      setErrorRecords(null);
-    }
-  }, [selectedLote, fetchRecordsData]);
 
   // 6) Carga datos totales de la empresa
   useEffect(() => {
@@ -228,28 +140,6 @@ export default function Dashboard() {
       }));
   }, [filteredRecords]);
 
-  // 7) Función para exportar Excel de datos por lote
-  const downloadExcel = () => {
-    if (records.length === 0) {
-      alert("No hay datos para exportar");
-      return;
-    }
-    const sheetData = records.map((r) => ({
-      Hora: new Date(r.timestamp).toLocaleString("es-CL"),
-      Conteo: r.count_in + r.count_out,
-      Dispositivo: r.dispositivo,
-    }));
-    const ws = XLSX.utils.json_to_sheet(sheetData);
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, "Conteos");
-    XLSX.writeFile(
-      wb,
-      `conteos_${selectedLote?.nombre || "sin_lote"}_${new Date()
-        .toISOString()
-        .slice(0, 19)
-        .replace(/[:T]/g, "-")}.xlsx`
-    );
-  };
 
   // ============== Renderizado ==============
   if (authLoading) return <div>Cargando…</div>;
@@ -264,7 +154,12 @@ export default function Dashboard() {
       <p className="mb-4">Lote activo: {activeLote ? activeLote.nombre : "Ninguno"}</p>
 
       <div className="mb-8 space-y-4">
-        <Select value={range} onValueChange={(v) => setRange(v as any)}>
+        <Select
+          value={range}
+          onValueChange={(v) =>
+            setRange(v as "today" | "last3" | "week" | "month")
+          }
+        >
           <SelectTrigger className="w-48">
             <SelectValue />
           </SelectTrigger>
@@ -362,113 +257,7 @@ export default function Dashboard() {
             </CardContent>
           </Card>
 
-          {/* Sub-pestañas: Resumen y Datos */}
-          <Tabs defaultValue="resumen">
-            <TabsList className="grid grid-cols-2 mb-4">
-              <TabsTrigger value="resumen">Resumen</TabsTrigger>
-              <TabsTrigger value="datos">Datos</TabsTrigger>
-            </TabsList>
-
-            {/* -------------------------------------------------- */}
-            {/* Resumen por Lote */}
-            <TabsContent value="resumen">
-              {!selectedLote ? (
-                <p className="text-center py-4">
-                  Selecciona primero un lote para ver el resumen.
-                </p>
-              ) : (
-                <>
-                  <div className="flex justify-end mb-2">
-                    <button
-                      onClick={fetchSummaryData}
-                      className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                    >
-                      🔄 Refrescar Resumen
-                    </button>
-                  </div>
-                  <ResumenLote
-                    summary={summary}
-                    loading={loadingSummary}
-                    error={errorSummary}
-                  />
-                </>
-              )}
-            </TabsContent>
-
-            {/* -------------------------------------------------- */}
-            {/* Datos por Lote */}
-            <TabsContent value="datos">
-              {!selectedLote ? (
-                <p className="text-center py-4">
-                  Selecciona primero un lote para ver los datos.
-                </p>
-              ) : (
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Datos de Conteos</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex justify-between mb-4">
-                      <div>Total registros: {records.length}</div>
-                      <div className="flex space-x-2">
-                        <button
-                          onClick={fetchRecordsData}
-                          className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                        >
-                          🔄 Refrescar Datos
-                        </button>
-                        <button
-                          onClick={downloadExcel}
-                          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-                        >
-                          Descargar Excel
-                        </button>
-                      </div>
-                    </div>
-
-                    {dataLoading ? (
-                      <p>Cargando datos…</p>
-                    ) : errorRecords ? (
-                      <p className="text-red-600">{errorRecords}</p>
-                    ) : (
-                      <div className="overflow-x-auto">
-                        <table className="min-w-full table-auto divide-y divide-gray-200">
-                          <thead className="bg-gray-50">
-                            <tr>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Hora
-                              </th>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Conteo
-                              </th>
-                              <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                                Dispositivo
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody className="bg-white divide-y divide-gray-200">
-                            {records.map((r) => (
-                              <tr key={r._id}>
-                                <td className="px-4 py-2">
-                                  {new Date(r.timestamp).toLocaleString(
-                                    "es-CL"
-                                  )}
-                                </td>
-                                <td className="px-4 py-2">
-                                  {r.count_in + r.count_out}
-                                </td>
-                                <td className="px-4 py-2">{r.dispositivo}</td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              )}
-            </TabsContent>
-          </Tabs>
+          <LoteDataTabs empresaId={data.empresaId} lote={selectedLote} />
         </TabsContent>
       </Tabs>
     </div>

--- a/my-project/src/components/app/lotes/lotedatatabs.tsx
+++ b/my-project/src/components/app/lotes/lotedatatabs.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SummaryLote } from "@/components/app/lotes/summarylote";
+import * as XLSX from "xlsx";
+
+export interface Lote {
+  id: string;
+  nombre: string;
+}
+
+interface ConteoRecord {
+  _id: string;
+  timestamp: string;
+  count_in: number;
+  count_out: number;
+  dispositivo: string;
+}
+
+interface LoteDataTabsProps {
+  empresaId: string;
+  lote: Lote | null;
+}
+
+export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
+  const [records, setRecords] = useState<ConteoRecord[]>([]);
+  const [dataLoading, setDataLoading] = useState(false);
+  const [errorRecords, setErrorRecords] = useState<string | null>(null);
+  const [refreshSummary, setRefreshSummary] = useState(0);
+
+  const fetchRecordsData = useCallback(() => {
+    if (!lote) {
+      setRecords([]);
+      return;
+    }
+    setDataLoading(true);
+    setErrorRecords(null);
+    fetch(`/api/conteos?empresaId=${empresaId}&loteId=${lote.id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Error al cargar los registros");
+        return res.json();
+      })
+      .then((arr: ConteoRecord[]) => {
+        const sortedArr = arr.sort(
+          (a, b) =>
+            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+        );
+        setRecords(sortedArr);
+      })
+      .catch((err) => setErrorRecords(err.message))
+      .finally(() => setDataLoading(false));
+  }, [empresaId, lote]);
+
+  useEffect(() => {
+    if (lote) {
+      fetchRecordsData();
+    } else {
+      setRecords([]);
+      setErrorRecords(null);
+    }
+  }, [lote, fetchRecordsData]);
+
+  const downloadExcel = () => {
+    if (records.length === 0) {
+      alert("No hay datos para exportar");
+      return;
+    }
+    const sheetData = records.map((r) => ({
+      Hora: new Date(r.timestamp).toLocaleString("es-CL"),
+      Conteo: r.count_in + r.count_out,
+      Dispositivo: r.dispositivo,
+    }));
+    const ws = XLSX.utils.json_to_sheet(sheetData);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Conteos");
+    XLSX.writeFile(
+      wb,
+      `conteos_${lote?.nombre || "sin_lote"}_${new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace(/[:T]/g, "-")}.xlsx`
+    );
+  };
+
+  return (
+    <Tabs defaultValue="resumen">
+      <TabsList className="grid grid-cols-2 mb-4">
+        <TabsTrigger value="resumen">Resumen</TabsTrigger>
+        <TabsTrigger value="datos">Datos</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="resumen">
+        {!lote ? (
+          <p className="text-center py-4">
+            Selecciona primero un lote para ver el resumen.
+          </p>
+        ) : (
+          <>
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={() => setRefreshSummary((r) => r + 1)}
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+              >
+                🔄 Refrescar Resumen
+              </button>
+            </div>
+            <SummaryLote loteId={lote.id} refreshKey={refreshSummary} />
+          </>
+        )}
+      </TabsContent>
+
+      <TabsContent value="datos">
+        {!lote ? (
+          <p className="text-center py-4">
+            Selecciona primero un lote para ver los datos.
+          </p>
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle>Datos de Conteos</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex justify-between mb-4">
+                <div>Total registros: {records.length}</div>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={fetchRecordsData}
+                    className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                  >
+                    🔄 Refrescar Datos
+                  </button>
+                  <button
+                    onClick={downloadExcel}
+                    className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                  >
+                    Descargar Excel
+                  </button>
+                </div>
+              </div>
+
+              {dataLoading ? (
+                <p>Cargando datos…</p>
+              ) : errorRecords ? (
+                <p className="text-red-600">{errorRecords}</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full table-auto divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                          Hora
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                          Conteo
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium uppercase">
+                          Dispositivo
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                      {records.map((r) => (
+                        <tr key={r._id}>
+                          <td className="px-4 py-2">
+                            {new Date(r.timestamp).toLocaleString("es-CL")}
+                          </td>
+                          <td className="px-4 py-2">{r.count_in + r.count_out}</td>
+                          <td className="px-4 py-2">{r.dispositivo}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}
+

--- a/my-project/src/components/app/lotes/summarylote.tsx
+++ b/my-project/src/components/app/lotes/summarylote.tsx
@@ -14,13 +14,14 @@ interface Summary {
 
 interface SummaryLoteProps {
   loteId: string;
-  /** (Opcional) Si deseas exponer desde el componente padre un callback
-   *  para “refrescar” externamente, puedes pasarlo por props,
-   *  por ejemplo onRefresh: () => void. Aquí asumimos que el botón
-   *  “Refrescar Resumen” vive en un contenedor superior. */
+  /**
+   * Opcional: si cambia este valor se volverá a solicitar el resumen.
+   * Permite que un componente padre fuerce la recarga sin cambiar el lote.
+   */
+  refreshKey?: number;
 }
 
-export function SummaryLote({ loteId }: SummaryLoteProps) {
+export function SummaryLote({ loteId, refreshKey }: SummaryLoteProps) {
   const [summaries, setSummaries] = useState<Summary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -48,7 +49,7 @@ export function SummaryLote({ loteId }: SummaryLoteProps) {
       .finally(() => {
         setLoading(false);
       });
-  }, [loteId]);
+  }, [loteId, refreshKey]);
 
   // Calcular el total de bulbos de todo el lote (suma de countIn + countOut por dispositivo)
   const totalBulbos = summaries.reduce(


### PR DESCRIPTION
## Summary
- create `LoteDataTabs` component to show resumen and datos with refresh buttons
- allow `SummaryLote` to accept a `refreshKey` prop for manual reload
- reuse the new component in the main dashboard and lotes pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684275d6653883308cb6b77fc4cbf678