### PR TITLE
Add flexible date range to volume summary

### DIFF
--- a/my-project/src/components/ui/date-range-picker.tsx
+++ b/my-project/src/components/ui/date-range-picker.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { CalendarIcon } from "@radix-ui/react-icons"
-import { addDays, format } from "date-fns"
+import { format } from "date-fns"
 import { DateRange } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -14,13 +14,34 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 
+export interface DatePickerWithRangeProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  value?: DateRange | undefined
+  onChange?: (range: DateRange | undefined) => void
+}
+
 export function DatePickerWithRange({
   className,
-}: React.HTMLAttributes<HTMLDivElement>) {
-  const [date, setDate] = React.useState<DateRange | undefined>({
-    from: new Date(2023, 0, 20),
-    to: addDays(new Date(2023, 0, 20), 20),
-  })
+  value,
+  onChange,
+}: DatePickerWithRangeProps) {
+  const [date, setDate] = React.useState<DateRange | undefined>(
+    value ?? {
+      from: new Date(),
+      to: new Date(),
+    }
+  )
+
+  React.useEffect(() => {
+    if (value) {
+      setDate(value)
+    }
+  }, [value])
+
+  const handleSelect = (range: DateRange | undefined) => {
+    setDate(range)
+    onChange?.(range)
+  }
 
   return (
     <div className={cn("grid gap-2", className)}>
@@ -55,7 +76,7 @@ export function DatePickerWithRange({
             mode="range"
             defaultMonth={date?.from}
             selected={date}
-            onSelect={setDate}
+            onSelect={handleSelect}
             numberOfMonths={2}
           />
         </PopoverContent>


### PR DESCRIPTION
## Summary
- update date-range picker component to accept external value and change callbacks
- replace quick range select with date range picker on dashboard
- compute total counts and average start hour across selected dates
- animate volume chart when date range changes

## Testing
- `npx next lint` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6845bcd1a5048330871d887a8b03f47e