### PR TITLE
Add Excel export for lot summary

### DIFF
--- a/my-project/src/app/api/lotes/summary/all/route.ts
+++ b/my-project/src/app/api/lotes/summary/all/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: Request) {
         id: lote._id.toString(),
         nombre: lote.nombre,
         conteo: total,
-        lastTimestamp: last ? last.timestamp : null,
+        lastTimestamp: last ? last.timestamp.toISOString() : null,
       };
     })
   );

--- a/my-project/src/app/api/lotes/summary/all/route.ts
+++ b/my-project/src/app/api/lotes/summary/all/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { connectDb } from "@/lib/mongodb";
+import { Lote } from "@/models/lotes";
+import { LoteActivity } from "@/models/loteactivity";
+import { Conteo } from "@/models/conteo";
+
+interface LoteCount {
+  id: string;
+  nombre: string;
+  conteo: number;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const empresaId = searchParams.get("empresaId");
+  if (!empresaId) {
+    return NextResponse.json(
+      { error: "empresaId is required" },
+      { status: 400 }
+    );
+  }
+
+  await connectDb();
+
+  // Obtener todos los lotes de la empresa
+  const lotes = await Lote.find({ empresaId }).sort({ fechaCreacion: -1 }).lean();
+  const now = new Date();
+
+  const summaries: LoteCount[] = await Promise.all(
+    lotes.map(async (lote) => {
+      // Sesiones de actividad para este lote
+      const acts = await LoteActivity.find({ loteId: lote._id }).lean();
+      if (acts.length === 0) {
+        return { id: lote._id.toString(), nombre: lote.nombre, conteo: 0 };
+      }
+      const orConds = acts.map(({ startTime, endTime }) => ({
+        timestamp: { $gte: startTime, $lte: endTime ?? now },
+      }));
+      const agg = await Conteo.aggregate<{
+        totalIn: number;
+        totalOut: number;
+      }>([
+        { $match: { $or: orConds } },
+        {
+          $group: {
+            _id: null,
+            totalIn: { $sum: "$count_in" },
+            totalOut: { $sum: "$count_out" },
+          },
+        },
+      ]);
+      const total = agg[0] ? agg[0].totalIn + agg[0].totalOut : 0;
+      return { id: lote._id.toString(), nombre: lote.nombre, conteo: total };
+    })
+  );
+
+  return NextResponse.json(summaries);
+}

--- a/my-project/src/app/api/lotes/summary/all/route.ts
+++ b/my-project/src/app/api/lotes/summary/all/route.ts
@@ -8,7 +8,8 @@ interface LoteCount {
   id: string;
   nombre: string;
   conteo: number;
-  lastTimestamp: Date | null;
+  firstTimestamp: string | null;
+  lastTimestamp: string | null;
 }
 
 export async function GET(request: Request) {
@@ -36,6 +37,7 @@ export async function GET(request: Request) {
           id: lote._id.toString(),
           nombre: lote.nombre,
           conteo: 0,
+          firstTimestamp: null,
           lastTimestamp: null,
         };
       }
@@ -60,11 +62,15 @@ export async function GET(request: Request) {
       const last = await Conteo.findOne({ $or: orConds })
         .sort({ timestamp: -1 })
         .lean();
+      const first = await Conteo.findOne({ $or: orConds })
+        .sort({ timestamp: 1 })
+        .lean();
 
       return {
         id: lote._id.toString(),
         nombre: lote.nombre,
         conteo: total,
+        firstTimestamp: first ? first.timestamp.toISOString() : null,
         lastTimestamp: last ? last.timestamp.toISOString() : null,
       };
     })

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -183,10 +183,12 @@ export default function Dashboard() {
         Lote: l.nombre,
         Conteo: l.conteo,
         "Último conteo": l.lastTimestamp
-          ? new Date(l.lastTimestamp).toLocaleString("es-CL")
-          : "—",
+          ? format(new Date(l.lastTimestamp), "yyyy-MM-dd HH:mm")
+          : "",
       }));
-      const ws = XLSX.utils.json_to_sheet(sheetData);
+      const ws = XLSX.utils.json_to_sheet(sheetData, {
+        header: ["Lote", "Conteo", "Último conteo"],
+      });
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Resumen");
       XLSX.writeFile(

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -159,6 +159,13 @@ export default function Dashboard() {
       }));
   }, [filteredRecords]);
 
+  const lastOverallTimestamp = useMemo(() => {
+    if (totalRecords.length === 0) return null;
+    return new Date(
+      Math.max(...totalRecords.map((r) => new Date(r.timestamp).getTime()))
+    );
+  }, [totalRecords]);
+
   const downloadSummaryExcel = async () => {
     if (!data) return;
     try {
@@ -166,8 +173,19 @@ export default function Dashboard() {
         `/api/lotes/summary/all?empresaId=${data.empresaId}`
       );
       if (!res.ok) throw new Error("Error al obtener resumen");
-      const arr: { id: string; nombre: string; conteo: number }[] = await res.json();
-      const sheetData = arr.map((l) => ({ Lote: l.nombre, Conteo: l.conteo }));
+      const arr: {
+        id: string;
+        nombre: string;
+        conteo: number;
+        lastTimestamp: string | null;
+      }[] = await res.json();
+      const sheetData = arr.map((l) => ({
+        Lote: l.nombre,
+        Conteo: l.conteo,
+        "Último conteo": l.lastTimestamp
+          ? new Date(l.lastTimestamp).toLocaleString("es-CL")
+          : "—",
+      }));
       const ws = XLSX.utils.json_to_sheet(sheetData);
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Resumen");
@@ -247,6 +265,18 @@ export default function Dashboard() {
                     </div>
                   ) : (
                     <p className="text-gray-500">Ningún lote activo</p>
+                  )}
+                </div>
+
+                {/* Último conteo */}
+                <div>
+                  <h3 className="text-lg font-medium mb-2">Último conteo</h3>
+                  {lastOverallTimestamp ? (
+                    <p className="text-xl font-semibold text-green-600">
+                      {lastOverallTimestamp.toLocaleString("es-CL")}
+                    </p>
+                  ) : (
+                    <p className="text-gray-500">—</p>
                   )}
                 </div>
 

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -166,6 +166,13 @@ export default function Dashboard() {
     );
   }, [totalRecords]);
 
+  const firstOverallTimestamp = useMemo(() => {
+    if (totalRecords.length === 0) return null;
+    return new Date(
+      Math.min(...totalRecords.map((r) => new Date(r.timestamp).getTime()))
+    );
+  }, [totalRecords]);
+
   const downloadSummaryExcel = async () => {
     if (!data) return;
     try {
@@ -177,17 +184,21 @@ export default function Dashboard() {
         id: string;
         nombre: string;
         conteo: number;
+        firstTimestamp: string | null;
         lastTimestamp: string | null;
       }[] = await res.json();
       const sheetData = arr.map((l) => ({
         Lote: l.nombre,
         Conteo: l.conteo,
+        "Primer conteo": l.firstTimestamp
+          ? format(new Date(l.firstTimestamp), "yyyy-MM-dd HH:mm")
+          : "",
         "Último conteo": l.lastTimestamp
           ? format(new Date(l.lastTimestamp), "yyyy-MM-dd HH:mm")
           : "",
       }));
       const ws = XLSX.utils.json_to_sheet(sheetData, {
-        header: ["Lote", "Conteo", "Último conteo"],
+        header: ["Lote", "Conteo", "Primer conteo", "Último conteo"],
       });
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "Resumen");
@@ -276,6 +287,18 @@ export default function Dashboard() {
                   {lastOverallTimestamp ? (
                     <p className="text-xl font-semibold text-green-600">
                       {lastOverallTimestamp.toLocaleString("es-CL")}
+                    </p>
+                  ) : (
+                    <p className="text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* Primer conteo */}
+                <div>
+                  <h3 className="text-lg font-medium mb-2">Primer conteo</h3>
+                  {firstOverallTimestamp ? (
+                    <p className="text-xl font-semibold text-green-600">
+                      {firstOverallTimestamp.toLocaleString("es-CL")}
                     </p>
                   ) : (
                     <p className="text-gray-500">—</p>


### PR DESCRIPTION
## Summary
- add API route to get count per lot for a company
- allow downloading an Excel with lot counts from the summary tab

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c20ca63648330b1e85a239b20314c