### PR TITLE
Remove 'Primer conteo' section from dashboard

### DIFF
--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -166,12 +166,6 @@ export default function Dashboard() {
     );
   }, [totalRecords]);
 
-  const firstOverallTimestamp = useMemo(() => {
-    if (totalRecords.length === 0) return null;
-    return new Date(
-      Math.min(...totalRecords.map((r) => new Date(r.timestamp).getTime()))
-    );
-  }, [totalRecords]);
 
   const downloadSummaryExcel = async () => {
     if (!data) return;
@@ -287,18 +281,6 @@ export default function Dashboard() {
                   {lastOverallTimestamp ? (
                     <p className="text-xl font-semibold text-green-600">
                       {lastOverallTimestamp.toLocaleString("es-CL")}
-                    </p>
-                  ) : (
-                    <p className="text-gray-500">—</p>
-                  )}
-                </div>
-
-                {/* Primer conteo */}
-                <div>
-                  <h3 className="text-lg font-medium mb-2">Primer conteo</h3>
-                  {firstOverallTimestamp ? (
-                    <p className="text-xl font-semibold text-green-600">
-                      {firstOverallTimestamp.toLocaleString("es-CL")}
                     </p>
                   ) : (
                     <p className="text-gray-500">—</p>


### PR DESCRIPTION
## Summary
- remove `firstOverallTimestamp` state from dashboard page
- delete UI block showing "Primer conteo" so the dashboard only displays the Excel download button and "Último conteo"

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685076718e708330b4344c9a3970cbf2