### PR TITLE
refactor: adapt conteo data model for directional events

### DIFF
--- a/my-project/src/app/api/conteos/route.ts
+++ b/my-project/src/app/api/conteos/route.ts
@@ -48,6 +48,7 @@ export async function GET(request: Request) {
 
   const conteos = await Conteo.find({ $or: orConds })
     .sort({ timestamp: 1 })
+    .select("timestamp direction dispositivo id perimeter servicioId")
     .lean();
 
   return NextResponse.json(conteos);

--- a/my-project/src/app/api/lotes/summary/all/route.ts
+++ b/my-project/src/app/api/lotes/summary/all/route.ts
@@ -54,8 +54,12 @@ export async function GET(request: Request) {
         {
           $group: {
             _id: null,
-            totalIn: { $sum: "$count_in" },
-            totalOut: { $sum: "$count_out" },
+            totalIn: {
+              $sum: { $cond: [{ $eq: ["$direction", "in"] }, 1, 0] },
+            },
+            totalOut: {
+              $sum: { $cond: [{ $eq: ["$direction", "out"] }, 1, 0] },
+            },
           },
         },
       ]);

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -7,8 +7,8 @@ import { Conteo } from "@/models/conteo";
 // 1) Definimos aquí la interfaz que describe cada resultado del $group:
 interface DeviceGroup {
   _id: string; // equivale a "dispositivo"
-  countIn: number; // suma de count_in
-  countOut: number; // suma de count_out
+  countIn: number; // cantidad de registros con direction 'in'
+  countOut: number; // cantidad de registros con direction 'out'
   lastTimestamp: Date; // máximo timestamp encontrado
 }
 
@@ -42,8 +42,12 @@ export async function GET(request: Request) {
     {
       $group: {
         _id: "$dispositivo",
-        countIn: { $sum: "$count_in" },
-        countOut: { $sum: "$count_out" },
+        countIn: {
+          $sum: { $cond: [{ $eq: ["$direction", "in"] }, 1, 0] },
+        },
+        countOut: {
+          $sum: { $cond: [{ $eq: ["$direction", "out"] }, 1, 0] },
+        },
         lastTimestamp: { $max: "$timestamp" },
       },
     },

--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -27,9 +27,10 @@ import { motion } from "framer-motion";
 interface ConteoRecord {
   _id: string;
   timestamp: string;
-  count_in: number;
-  count_out: number;
+  direction: "in" | "out";
   dispositivo: string;
+  id: number;
+  perimeter: number;
 }
 
 export default function Dashboard() {
@@ -88,11 +89,7 @@ export default function Dashboard() {
 
   // Calcular suma total de conteos
   useEffect(() => {
-    const sum = totalRecords.reduce(
-      (acc, r) => acc + r.count_in + r.count_out,
-      0
-    );
-    setTotalSum(sum);
+    setTotalSum(totalRecords.length);
   }, [totalRecords]);
 
   const filteredRecords = useMemo(() => {
@@ -106,10 +103,7 @@ export default function Dashboard() {
   }, [totalRecords, dateRange]);
 
   const totalRangeCount = useMemo(() => {
-    return filteredRecords.reduce(
-      (acc, r) => acc + r.count_in + r.count_out,
-      0
-    );
+    return filteredRecords.length;
   }, [filteredRecords]);
 
   const startInfo = useMemo(() => {
@@ -145,7 +139,7 @@ export default function Dashboard() {
       const d = new Date(r.timestamp);
       d.setMinutes(0, 0, 0);
       const key = d.getTime();
-      map.set(key, (map.get(key) ?? 0) + r.count_in + r.count_out);
+      map.set(key, (map.get(key) ?? 0) + 1);
     });
     return Array.from(map.entries())
       .sort((a, b) => a[0] - b[0])

--- a/my-project/src/components/app/lotes/lotedatatabs.tsx
+++ b/my-project/src/components/app/lotes/lotedatatabs.tsx
@@ -14,9 +14,10 @@ export interface Lote {
 interface ConteoRecord {
   _id: string;
   timestamp: string;
-  count_in: number;
-  count_out: number;
+  direction: "in" | "out";
   dispositivo: string;
+  id: number;
+  perimeter: number;
 }
 
 interface LoteDataTabsProps {
@@ -69,7 +70,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
     }
     const sheetData = records.map((r) => ({
       Hora: new Date(r.timestamp).toLocaleString("es-CL"),
-      Conteo: r.count_in + r.count_out,
+      Direccion: r.direction,
       Dispositivo: r.dispositivo,
     }));
     const ws = XLSX.utils.json_to_sheet(sheetData);
@@ -153,7 +154,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
                           Hora
                         </th>
                         <th className="px-4 py-2 text-left text-xs font-medium uppercase">
-                          Conteo
+                          Dirección
                         </th>
                         <th className="px-4 py-2 text-left text-xs font-medium uppercase">
                           Dispositivo
@@ -166,7 +167,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
                           <td className="px-4 py-2">
                             {new Date(r.timestamp).toLocaleString("es-CL")}
                           </td>
-                          <td className="px-4 py-2">{r.count_in + r.count_out}</td>
+                          <td className="px-4 py-2">{r.direction}</td>
                           <td className="px-4 py-2">{r.dispositivo}</td>
                         </tr>
                       ))}

--- a/my-project/src/models/conteo.ts
+++ b/my-project/src/models/conteo.ts
@@ -1,22 +1,26 @@
 import { Schema, Document, models, model } from "mongoose";
 
 export interface ConteoDoc extends Document {
+  id: number;
+  perimeter: number;
+  direction: "in" | "out";
   timestamp: Date;
-  countIn: number;
-  countOut: number;
   dispositivo: string;
   servicioId: string;
 }
 
 const ConteoSchema = new Schema<ConteoDoc>({
+  id: { type: Number, required: true },
+  perimeter: { type: Number, required: true },
+  direction: { type: String, enum: ["in", "out"], required: true },
   timestamp: { type: Date, required: true, default: () => new Date() },
-  countIn: { type: Number, required: true },
-  countOut: { type: Number, required: true },
   dispositivo: { type: String, required: true },
   servicioId: { type: String, required: true },
 });
 
-// Índice para mejorar rendimiento en consultas por fecha
+// Índices para mejorar rendimiento en consultas frecuentes
 ConteoSchema.index({ timestamp: -1 });
+ConteoSchema.index({ direction: 1 });
+ConteoSchema.index({ dispositivo: 1 });
 
 export const Conteo = models.Conteo || model<ConteoDoc>("Conteo", ConteoSchema);


### PR DESCRIPTION
## Summary
- use directional events instead of separate in/out counts
- aggregate counts by direction in lote summary endpoints
- expose direction in conteo APIs and UI tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4b7872888330950d2e5651814dcc