### PR TITLE
Add services table and filter dashboard counts by service

### DIFF
--- a/my-project/src/app/api/conteos/route.ts
+++ b/my-project/src/app/api/conteos/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const loteId = searchParams.get("loteId");
   const empresaId = searchParams.get("empresaId");
+  const servicioId = searchParams.get("servicioId");
 
   if (!loteId && !empresaId) {
     return NextResponse.json(
@@ -46,7 +47,12 @@ export async function GET(request: Request) {
     timestamp: { $gte: startTime, $lte: endTime ?? now },
   }));
 
-  const conteos = await Conteo.find({ $or: orConds })
+  const query: Record<string, unknown> = { $or: orConds };
+  if (servicioId) {
+    query.servicioId = servicioId;
+  }
+
+  const conteos = await Conteo.find(query)
     .sort({ timestamp: 1 })
     .select("timestamp direction dispositivo id perimeter servicioId")
     .lean();

--- a/my-project/src/app/api/servicios/route.ts
+++ b/my-project/src/app/api/servicios/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { connectDb } from "@/lib/mongodb";
+import { Servicio } from "@/models/servicio";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const empresaId = searchParams.get("empresaId");
+  if (!empresaId) {
+    return NextResponse.json(
+      { error: "empresaId es requerido" },
+      { status: 400 }
+    );
+  }
+  await connectDb();
+  const servicios = await Servicio.find({ empresaId })
+    .select("_id nombre")
+    .lean<{ _id: unknown; nombre: string }[]>();
+  return NextResponse.json(
+    servicios.map((s) => ({ id: String(s._id), nombre: s.nombre }))
+  );
+}
+
+export async function POST(request: Request) {
+  const { empresaId, nombre } = await request.json();
+  if (!empresaId || !nombre) {
+    return NextResponse.json(
+      { error: "empresaId y nombre son requeridos" },
+      { status: 400 }
+    );
+  }
+  await connectDb();
+  const servicio = await Servicio.create({ empresaId, nombre });
+  return NextResponse.json(
+    { id: servicio._id.toString(), nombre: servicio.nombre },
+    { status: 201 }
+  );
+}

--- a/my-project/src/components/app/servicios/servicioselector.tsx
+++ b/my-project/src/components/app/servicios/servicioselector.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Check, Search } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import React from "react";
+
+export interface Servicio {
+  id: string;
+  nombre: string;
+}
+
+interface ServicioSelectorProps {
+  servicios: Servicio[];
+  selectedServicio: Servicio | null;
+  loading: boolean;
+  onSelect: (servicio: Servicio) => void;
+  onSelectNone: () => void;
+}
+
+export function ServicioSelector({
+  servicios,
+  selectedServicio,
+  loading,
+  onSelect,
+  onSelectNone,
+}: ServicioSelectorProps) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState("");
+
+  const filtered = servicios.filter((s) =>
+    s.nombre.toLowerCase().includes(search.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-24">
+        Cargando servicios…
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex flex-col space-y-2">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Servicio</h2>
+          <Button onClick={() => setOpen(true)}>Cambiar</Button>
+        </div>
+        <div className="bg-white rounded-lg border p-4 flex justify-between items-center">
+          <div>
+            <p className="text-sm text-gray-500">Mostrando datos de:</p>
+            <p className="text-xl font-medium">
+              {selectedServicio?.nombre || "Todos"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md md:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="text-xl">Seleccionar Servicio</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-500" />
+              <Input
+                placeholder="Buscar servicios..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-8"
+                autoFocus
+              />
+            </div>
+            <ScrollArea className="h-72 rounded-md border">
+              <div className="p-2 space-y-1">
+                <button
+                  onClick={() => {
+                    onSelectNone();
+                    setOpen(false);
+                  }}
+                  className={`w-full flex items-center justify-between p-2 rounded-md text-left ${
+                    selectedServicio === null
+                      ? "bg-primary-50 text-primary-600"
+                      : "hover:bg-gray-100"
+                  }`}
+                >
+                  <div className="font-medium">Todos</div>
+                  {selectedServicio === null && (
+                    <Check className="h-4 w-4 text-primary-600" />
+                  )}
+                </button>
+
+                {filtered.length > 0 ? (
+                  filtered.map((servicio) => (
+                    <button
+                      key={servicio.id}
+                      onClick={() => {
+                        onSelect(servicio);
+                        setOpen(false);
+                      }}
+                      className={`w-full flex items-center justify-between p-2 rounded-md text-left ${
+                        selectedServicio?.id === servicio.id
+                          ? "bg-primary-50 text-primary-600"
+                          : "hover:bg-gray-100"
+                      }`}
+                    >
+                      <div className="font-medium">{servicio.nombre}</div>
+                      {selectedServicio?.id === servicio.id && (
+                        <Check className="h-4 w-4 text-primary-600" />
+                      )}
+                    </button>
+                  ))
+                ) : (
+                  <div className="p-4 text-center text-gray-500">
+                    No se encontraron servicios
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+            <div className="flex justify-end">
+              <Button onClick={() => setOpen(false)}>Cerrar</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/my-project/src/models/servicio.ts
+++ b/my-project/src/models/servicio.ts
@@ -1,0 +1,13 @@
+import { Schema, Document, models, model } from "mongoose";
+
+export interface ServicioDoc extends Document {
+  nombre: string;
+  empresaId: string;
+}
+
+const ServicioSchema = new Schema<ServicioDoc>({
+  nombre: { type: String, required: true },
+  empresaId: { type: String, required: true },
+});
+
+export const Servicio = models.Servicio || model<ServicioDoc>("Servicio", ServicioSchema);


### PR DESCRIPTION
## Summary
- add `Servicio` model and API to store company services
- filter conteos API by selected service
- add service selector on dashboard to show conteos for chosen service

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af322ee238833098ef13ce723fabe1