### PR TITLE
Add servicio filtering via sidebar selection

### DIFF
--- a/my-project/src/app/app/layout.tsx
+++ b/my-project/src/app/app/layout.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation"; // Importante para cerrar sidebar
 import { AppSidebar } from "@/components/app/AppSidebar"; // Ajusta la ruta
 import { AppNavbar } from "@/components/app/AppNavbar"; // Ajusta la ruta
 import AuthContext from "../context/AuthContext"; // Ajusta la ruta
+import { ServicioProvider } from "../context/ServicioContext";
 import ProtectedRoute from "./ProtectedRoute"; // Ajusta laruta
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
@@ -26,40 +27,42 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <AuthContext>
-      {" "}
-      {/* AuthContext envuelve todo */}
-      <ProtectedRoute>
+      <ServicioProvider>
         {" "}
-        {/* ProtectedRoute después de AuthContext */}
-        <div className="flex min-h-screen flex-col bg-gray-100">
+        {/* AuthContext envuelve todo */}
+        <ProtectedRoute>
           {" "}
-          {/* Fondo claro para el contenido */}
-          {/* Navbar Fijo */}
-          <AppNavbar
-            isSidebarOpen={isSidebarOpen}
-            toggleSidebar={toggleSidebar}
-          />
-          <div className="flex flex-1 pt-16">
+          {/* ProtectedRoute después de AuthContext */}
+          <div className="flex min-h-screen flex-col bg-gray-100">
             {" "}
-            {/* pt-16 para compensar altura del navbar */}
-            {/* Sidebar */}
-            <AppSidebar isOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
-            {/* Overlay para el contenido cuando el sidebar está abierto en móviles */}
-            {isSidebarOpen && (
-              <div
-                onClick={toggleSidebar}
-                className="fixed inset-0 z-20 bg-black/50 backdrop-blur-sm md:hidden"
-                aria-hidden="true"
-              />
-            )}
-            {/* Contenido Principal */}
-            <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
-              {/* El div que tenías para centrar ya no es necesario aquí, se maneja por página */}
-              {children}
-            </main>
+            {/* Fondo claro para el contenido */}
+            {/* Navbar Fijo */}
+            <AppNavbar
+              isSidebarOpen={isSidebarOpen}
+              toggleSidebar={toggleSidebar}
+            />
+            <div className="flex flex-1 pt-16">
+              {" "}
+              {/* pt-16 para compensar altura del navbar */}
+              {/* Sidebar */}
+              <AppSidebar isOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
+              {/* Overlay para el contenido cuando el sidebar está abierto en móviles */}
+              {isSidebarOpen && (
+                <div
+                  onClick={toggleSidebar}
+                  className="fixed inset-0 z-20 bg-black/50 backdrop-blur-sm md:hidden"
+                  aria-hidden="true"
+                />
+              )}
+              {/* Contenido Principal */}
+              <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
+                {/* El div que tenías para centrar ya no es necesario aquí, se maneja por página */}
+                {children}
+              </main>
+            </div>
           </div>
-        </div>
-      </ProtectedRoute>
+        </ProtectedRoute>
+      </ServicioProvider>
     </AuthContext>
   );
 }

--- a/my-project/src/app/context/ServicioContext.tsx
+++ b/my-project/src/app/context/ServicioContext.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { AuthenticationContext } from "./AuthContext";
+
+export interface Servicio {
+  id: string;
+  nombre: string;
+}
+
+interface ServicioState {
+  servicios: Servicio[];
+  selectedServicio: Servicio | null;
+  loading: boolean;
+  setSelectedServicio: (servicio: Servicio | null) => void;
+}
+
+export const ServicioContext = createContext<ServicioState>({
+  servicios: [],
+  selectedServicio: null,
+  loading: false,
+  setSelectedServicio: () => {},
+});
+
+export function ServicioProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { data } = useContext(AuthenticationContext);
+  const [servicios, setServicios] = useState<Servicio[]>([]);
+  const [selectedServicio, setSelectedServicio] = useState<Servicio | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!data) return;
+    setLoading(true);
+    fetch(`/api/servicios?empresaId=${data.empresaId}`)
+      .then((res) => res.json())
+      .then((arr: Servicio[]) => setServicios(arr))
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [data]);
+
+  return (
+    <ServicioContext.Provider
+      value={{ servicios, selectedServicio, loading, setSelectedServicio }}
+    >
+      {children}
+    </ServicioContext.Provider>
+  );
+}
+
+export function useServicio() {
+  return useContext(ServicioContext);
+}

--- a/my-project/src/components/app/AppSidebar.tsx
+++ b/my-project/src/components/app/AppSidebar.tsx
@@ -8,6 +8,14 @@ import { Home, Settings, Archive, LogOut, ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import clsx from "clsx";
 import { AuthenticationContext } from "../../app/context/AuthContext"; // Ajusta la ruta si es necesario
+import { useServicio } from "@/app/context/ServicioContext";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 
 // Definimos un tipo más específico para los iconos
 type MenuItem = {
@@ -34,6 +42,8 @@ export function AppSidebar({ isOpen, toggleSidebar }: AppSidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { setAuthState } = useContext(AuthenticationContext);
+  const { servicios, selectedServicio, setSelectedServicio, loading } =
+    useServicio();
 
   const handleLogout = async () => {
     try {
@@ -82,6 +92,33 @@ export function AppSidebar({ isOpen, toggleSidebar }: AppSidebarProps) {
 
       {/* Contenido del Sidebar */}
       <nav className="flex flex-1 flex-col space-y-6 overflow-y-auto p-4">
+        {/* Selector de Servicio */}
+        <div>
+          <span className="px-4 text-xs font-semibold uppercase text-emerald-300">
+            Servicio
+          </span>
+          <Select
+            value={selectedServicio?.id ?? "all"}
+            onValueChange={(v) => {
+              const svc = servicios.find((s) => s.id === v);
+              setSelectedServicio(v === "all" ? null : svc || null);
+            }}
+            disabled={loading}
+          >
+            <SelectTrigger className="mt-2">
+              <SelectValue placeholder={loading ? "Cargando..." : "Todos"} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              {servicios.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.nombre}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
         {/* Navegación Principal */}
         <div>
           <span className="px-4 text-xs font-semibold uppercase text-emerald-300">

--- a/my-project/src/components/app/lotes/lotedatatabs.tsx
+++ b/my-project/src/components/app/lotes/lotedatatabs.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SummaryLote } from "@/components/app/lotes/summarylote";
 import * as XLSX from "xlsx";
+import { useServicio } from "@/app/context/ServicioContext";
 
 export interface Lote {
   id: string;
@@ -30,6 +31,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
   const [dataLoading, setDataLoading] = useState(false);
   const [errorRecords, setErrorRecords] = useState<string | null>(null);
   const [refreshSummary, setRefreshSummary] = useState(0);
+  const { selectedServicio } = useServicio();
 
   const fetchRecordsData = useCallback(() => {
     if (!lote) {
@@ -38,7 +40,9 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
     }
     setDataLoading(true);
     setErrorRecords(null);
-    fetch(`/api/conteos?empresaId=${empresaId}&loteId=${lote.id}`)
+    const params = new URLSearchParams({ empresaId, loteId: lote.id });
+    if (selectedServicio) params.append("servicioId", selectedServicio.id);
+    fetch(`/api/conteos?${params.toString()}`)
       .then((res) => {
         if (!res.ok) throw new Error("Error al cargar los registros");
         return res.json();
@@ -52,7 +56,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
       })
       .catch((err) => setErrorRecords(err.message))
       .finally(() => setDataLoading(false));
-  }, [empresaId, lote]);
+  }, [empresaId, lote, selectedServicio]);
 
   useEffect(() => {
     if (lote) {

--- a/my-project/src/components/app/lotes/summarylote.tsx
+++ b/my-project/src/components/app/lotes/summarylote.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useServicio } from "@/app/context/ServicioContext";
 
 interface Summary {
   dispositivo: string;
@@ -25,6 +26,7 @@ export function SummaryLote({ loteId, refreshKey }: SummaryLoteProps) {
   const [summaries, setSummaries] = useState<Summary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { selectedServicio } = useServicio();
 
   useEffect(() => {
     if (!loteId) {
@@ -34,7 +36,9 @@ export function SummaryLote({ loteId, refreshKey }: SummaryLoteProps) {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/lotes/summary?loteId=${loteId}`)
+    const params = new URLSearchParams({ loteId });
+    if (selectedServicio) params.append("servicioId", selectedServicio.id);
+    fetch(`/api/lotes/summary?${params.toString()}`)
       .then((res) => {
         if (!res.ok) throw new Error("Error al cargar el resumen");
         return res.json();
@@ -49,7 +53,7 @@ export function SummaryLote({ loteId, refreshKey }: SummaryLoteProps) {
       .finally(() => {
         setLoading(false);
       });
-  }, [loteId, refreshKey]);
+  }, [loteId, refreshKey, selectedServicio]);
 
   // Calcular el total de bulbos de todo el lote (suma de countIn + countOut por dispositivo)
   const totalBulbos = summaries.reduce(


### PR DESCRIPTION
## Summary
- introduce `ServicioContext` for empresa services and selected servicio
- add servicio dropdown to sidebar and global provider
- filter lotes and conteos APIs by selected servicio

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af952a2b488330a3a3e9bbc2c77b8c