### PR TITLE
Link lotes to servicio

### DIFF
--- a/my-project/src/app/app/page.tsx
+++ b/my-project/src/app/app/page.tsx
@@ -59,22 +59,22 @@ export default function Dashboard() {
 
   // ============== Funciones de carga (fetch) ==============
   useEffect(() => {
-    if (!data) return;
+    if (!data || !selectedServicio) return;
     setLoadingLotes(true);
-    fetch(`/api/lotes?empresaId=${data.empresaId}`)
+    fetch(`/api/lotes?servicioId=${selectedServicio.id}`)
       .then((res) => res.json())
       .then((arr: Lote[]) => setLotes(arr))
       .catch((err) => console.error(err))
       .finally(() => setLoadingLotes(false));
-  }, [data]);
-  // Lote activo actual de la empresa
+  }, [data, selectedServicio]);
+  // Lote activo actual del servicio
   useEffect(() => {
-    if (!data) return;
-    fetch(`/api/lotes/activity/last?empresaId=${data.empresaId}`)
+    if (!data || !selectedServicio) return;
+    fetch(`/api/lotes/activity/last?servicioId=${selectedServicio.id}`)
       .then((res) => res.json())
       .then((l: Lote | null) => setActiveLote(l))
       .catch(() => setActiveLote(null));
-  }, [data]);
+  }, [data, selectedServicio]);
 
   //  Carga datos totales de la empresa
   useEffect(() => {
@@ -370,7 +370,7 @@ export default function Dashboard() {
             </CardContent>
           </Card>
 
-          <LoteDataTabs empresaId={data.empresaId} lote={selectedLote} />
+          <LoteDataTabs lote={selectedLote} />
         </TabsContent>
       </Tabs>
     </div>

--- a/my-project/src/components/app/lotes/lotedatatabs.tsx
+++ b/my-project/src/components/app/lotes/lotedatatabs.tsx
@@ -22,11 +22,10 @@ interface ConteoRecord {
 }
 
 interface LoteDataTabsProps {
-  empresaId: string;
   lote: Lote | null;
 }
 
-export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
+export function LoteDataTabs({ lote }: LoteDataTabsProps) {
   const [records, setRecords] = useState<ConteoRecord[]>([]);
   const [dataLoading, setDataLoading] = useState(false);
   const [errorRecords, setErrorRecords] = useState<string | null>(null);
@@ -40,7 +39,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
     }
     setDataLoading(true);
     setErrorRecords(null);
-    const params = new URLSearchParams({ empresaId, loteId: lote.id });
+    const params = new URLSearchParams({ loteId: lote.id });
     if (selectedServicio) params.append("servicioId", selectedServicio.id);
     fetch(`/api/conteos?${params.toString()}`)
       .then((res) => {
@@ -56,7 +55,7 @@ export function LoteDataTabs({ empresaId, lote }: LoteDataTabsProps) {
       })
       .catch((err) => setErrorRecords(err.message))
       .finally(() => setDataLoading(false));
-  }, [empresaId, lote, selectedServicio]);
+  }, [lote, selectedServicio]);
 
   useEffect(() => {
     if (lote) {

--- a/my-project/src/models/lotes.ts
+++ b/my-project/src/models/lotes.ts
@@ -3,7 +3,7 @@ import mongoose, { Document, Model } from "mongoose";
 export interface LoteDocument extends Document {
   nombre: string;
   fechaCreacion: Date;
-  empresaId: string;
+  servicioId: string;
 }
 
 const LoteSchema = new mongoose.Schema<LoteDocument>({
@@ -16,10 +16,10 @@ const LoteSchema = new mongoose.Schema<LoteDocument>({
     required: true,
     default: (): Date => new Date(),
   },
-  // empresaId es un string que referencia a Empresa._id
-  empresaId: {
+  // servicioId es un string que referencia a Servicio._id
+  servicioId: {
     type: String,
-    ref: "Empresa",
+    ref: "Servicio",
     required: true,
   },
 });


### PR DESCRIPTION
## Summary
- reference `servicioId` on Lote model instead of `empresaId`
- update lote APIs and pages to fetch and create by current servicio
- remove unused empresaId from LoteDataTabs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(warnings: querySrv ENOTFOUND _mongodb._tcp.stass.vk4ne.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68afafd4700c8330a319bc13d5d7c0da