### PR TITLE
[codex] Improve lotes filters UI

### DIFF
--- a/my-project/src/app/api/lotes/global/export/route.ts
+++ b/my-project/src/app/api/lotes/global/export/route.ts
@@ -15,6 +15,10 @@ export async function GET(request: Request) {
     );
   }
 
-  const payload = await getGlobalLotesPayload(query);
-  return NextResponse.json(payload);
+  const payload = await getGlobalLotesPayload(query, { paginate: false });
+  return NextResponse.json({
+    data: payload.data,
+    total: payload.total,
+    summary: payload.summary,
+  });
 }

--- a/my-project/src/app/api/lotes/global/query.ts
+++ b/my-project/src/app/api/lotes/global/query.ts
@@ -1,0 +1,593 @@
+import { db } from "@/db";
+import {
+  lote,
+  loteServicio,
+  loteStats,
+  loteSession,
+  servicio,
+  variedad,
+  producto,
+  proceso,
+  tipoProceso,
+  subvariedad,
+} from "@/db/schema";
+import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+
+const SORT_FIELDS = [
+  "codigoLote",
+  "producto",
+  "variedad",
+  "etapa",
+  "totalBulbs",
+  "createdAt",
+  "lastTs",
+  "estado",
+] as const;
+
+export type LoteSortField = (typeof SORT_FIELDS)[number];
+export type SortOrder = "asc" | "desc";
+export type EstadoFilter = "todos" | "activo" | "inactivo";
+export type ActivityFilter =
+  | "todos"
+  | "con_datos"
+  | "sin_datos"
+  | "ultimos_7"
+  | "ultimos_30";
+
+export interface GlobalLotesQuery {
+  empresaId: string;
+  search?: string;
+  productoId?: string;
+  variedadId?: string;
+  subvariedadId?: string;
+  estado: EstadoFilter;
+  tipoProcesoId?: string;
+  servicioId?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  activity: ActivityFilter;
+  minBulbs?: number;
+  maxBulbs?: number;
+  sort: LoteSortField;
+  order: SortOrder;
+  page: number;
+  limit: number;
+}
+
+interface StatsByLote {
+  totalBulbs: number;
+  firstTs: Date | null;
+  lastTs: Date | null;
+}
+
+interface LatestAssignment {
+  servicioId: string;
+  servicioNombre: string;
+  tipoProcesoId: string | null;
+  tipoProcesoNombre: string | null;
+}
+
+export interface LoteGlobalRow {
+  id: string;
+  codigoLote: string | null;
+  createdAt: string | null;
+  variedadId: string | null;
+  variedadNombre: string | null;
+  variedadTipo: string | null;
+  subvariedadId: string | null;
+  subvariedadNombre: string | null;
+  productoId: string | null;
+  productoNombre: string | null;
+  totalBulbs: number;
+  firstTs: string | null;
+  lastTs: string | null;
+  isActive: boolean;
+  etapaActualId: string | null;
+  etapaActual: string | null;
+  servicioActualId: string | null;
+  servicioActual: string | null;
+}
+
+export interface LoteFacetOption {
+  id: string;
+  nombre: string;
+  count: number;
+}
+
+export interface LoteVariedadFacetOption extends LoteFacetOption {
+  productoId: string | null;
+  productoNombre: string | null;
+  tipo: string | null;
+}
+
+export interface LoteGlobalFacets {
+  productos: LoteFacetOption[];
+  variedades: LoteVariedadFacetOption[];
+  subvariedades: Array<LoteFacetOption & { variedadId: string | null }>;
+  etapas: LoteFacetOption[];
+  servicios: Array<LoteFacetOption & { tipoProcesoId: string | null }>;
+}
+
+export interface LoteGlobalSummary {
+  allTotal: number;
+  total: number;
+  active: number;
+  inactive: number;
+  withData: number;
+  withoutData: number;
+  recent7: number;
+  totalBulbs: number;
+  lastActivity: string | null;
+}
+
+export interface GlobalLotesPayload {
+  data: LoteGlobalRow[];
+  total: number;
+  page: number;
+  limit: number;
+  summary: LoteGlobalSummary;
+  facets: LoteGlobalFacets;
+}
+
+function readTextParam(searchParams: URLSearchParams, key: string) {
+  const value = searchParams.get(key)?.trim();
+  return value || undefined;
+}
+
+function readNumberParam(searchParams: URLSearchParams, key: string) {
+  const value = searchParams.get(key);
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isSortField(value: string | null): value is LoteSortField {
+  return SORT_FIELDS.includes(value as LoteSortField);
+}
+
+function isEstadoFilter(value: string | null): value is EstadoFilter {
+  return value === "activo" || value === "inactivo" || value === "todos";
+}
+
+function isActivityFilter(value: string | null): value is ActivityFilter {
+  return (
+    value === "con_datos" ||
+    value === "sin_datos" ||
+    value === "ultimos_7" ||
+    value === "ultimos_30" ||
+    value === "todos"
+  );
+}
+
+export function parseGlobalLotesQuery(
+  searchParams: URLSearchParams
+): GlobalLotesQuery | null {
+  const empresaId = readTextParam(searchParams, "empresaId");
+  if (!empresaId) return null;
+
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(searchParams.get("limit") ?? "25", 10))
+  );
+  const rawSort = searchParams.get("sort");
+  const rawOrder = searchParams.get("order");
+  const rawEstado = searchParams.get("estado");
+  const rawActivity = searchParams.get("activity");
+
+  return {
+    empresaId,
+    search: readTextParam(searchParams, "search"),
+    productoId: readTextParam(searchParams, "productoId"),
+    variedadId: readTextParam(searchParams, "variedadId"),
+    subvariedadId: readTextParam(searchParams, "subvariedadId"),
+    estado: isEstadoFilter(rawEstado) ? rawEstado : "todos",
+    tipoProcesoId: readTextParam(searchParams, "tipoProcesoId"),
+    servicioId: readTextParam(searchParams, "servicioId"),
+    createdFrom: readTextParam(searchParams, "createdFrom"),
+    createdTo: readTextParam(searchParams, "createdTo"),
+    activity: isActivityFilter(rawActivity) ? rawActivity : "todos",
+    minBulbs: readNumberParam(searchParams, "minBulbs"),
+    maxBulbs: readNumberParam(searchParams, "maxBulbs"),
+    sort: isSortField(rawSort) ? rawSort : "createdAt",
+    order: rawOrder === "asc" ? "asc" : "desc",
+    page,
+    limit,
+  };
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function parseDateBoundary(value: string | undefined, endOfDay = false) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  if (endOfDay) date.setHours(23, 59, 59, 999);
+  return date;
+}
+
+function compareNullableText(a: string | null, b: string | null) {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b, "es");
+}
+
+function compareNullableDate(a: string | null, b: string | null) {
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return new Date(a).getTime() - new Date(b).getTime();
+}
+
+function addFacetCount<T extends { count: number }>(
+  map: Map<string, T>,
+  id: string | null | undefined
+) {
+  if (!id) return;
+  const item = map.get(id);
+  if (item) item.count += 1;
+}
+
+function buildFacets(rows: LoteGlobalRow[]): LoteGlobalFacets {
+  const productos = new Map<string, LoteFacetOption>();
+  const variedades = new Map<string, LoteVariedadFacetOption>();
+  const subvariedades = new Map<
+    string,
+    LoteFacetOption & { variedadId: string | null }
+  >();
+  const etapas = new Map<string, LoteFacetOption>();
+  const servicios = new Map<
+    string,
+    LoteFacetOption & { tipoProcesoId: string | null }
+  >();
+
+  for (const row of rows) {
+    if (row.productoId && !productos.has(row.productoId)) {
+      productos.set(row.productoId, {
+        id: row.productoId,
+        nombre: row.productoNombre ?? "Sin producto",
+        count: 0,
+      });
+    }
+    if (row.variedadId && !variedades.has(row.variedadId)) {
+      variedades.set(row.variedadId, {
+        id: row.variedadId,
+        nombre: row.variedadNombre ?? "Sin variedad",
+        count: 0,
+        productoId: row.productoId,
+        productoNombre: row.productoNombre,
+        tipo: row.variedadTipo,
+      });
+    }
+    if (row.subvariedadId && !subvariedades.has(row.subvariedadId)) {
+      subvariedades.set(row.subvariedadId, {
+        id: row.subvariedadId,
+        nombre: row.subvariedadNombre ?? "Sin subvariedad",
+        count: 0,
+        variedadId: row.variedadId,
+      });
+    }
+    if (row.etapaActualId && !etapas.has(row.etapaActualId)) {
+      etapas.set(row.etapaActualId, {
+        id: row.etapaActualId,
+        nombre: row.etapaActual ?? "Sin etapa",
+        count: 0,
+      });
+    }
+    if (row.servicioActualId && !servicios.has(row.servicioActualId)) {
+      servicios.set(row.servicioActualId, {
+        id: row.servicioActualId,
+        nombre: row.servicioActual ?? "Sin servicio",
+        count: 0,
+        tipoProcesoId: row.etapaActualId,
+      });
+    }
+
+    addFacetCount(productos, row.productoId);
+    addFacetCount(variedades, row.variedadId);
+    addFacetCount(subvariedades, row.subvariedadId);
+    addFacetCount(etapas, row.etapaActualId);
+    addFacetCount(servicios, row.servicioActualId);
+  }
+
+  const sortByName = <T extends { nombre: string }>(a: T, b: T) =>
+    a.nombre.localeCompare(b.nombre, "es");
+
+  return {
+    productos: Array.from(productos.values()).sort(sortByName),
+    variedades: Array.from(variedades.values()).sort(sortByName),
+    subvariedades: Array.from(subvariedades.values()).sort(sortByName),
+    etapas: Array.from(etapas.values()).sort(sortByName),
+    servicios: Array.from(servicios.values()).sort(sortByName),
+  };
+}
+
+function buildSummary(rows: LoteGlobalRow[], allTotal: number): LoteGlobalSummary {
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const lastActivity = rows.reduce<string | null>((latest, row) => {
+    if (!row.lastTs) return latest;
+    if (!latest) return row.lastTs;
+    return new Date(row.lastTs).getTime() > new Date(latest).getTime()
+      ? row.lastTs
+      : latest;
+  }, null);
+
+  return {
+    allTotal,
+    total: rows.length,
+    active: rows.filter((row) => row.isActive).length,
+    inactive: rows.filter((row) => !row.isActive).length,
+    withData: rows.filter((row) => row.totalBulbs > 0 || row.lastTs).length,
+    withoutData: rows.filter((row) => row.totalBulbs === 0 && !row.lastTs).length,
+    recent7: rows.filter(
+      (row) => row.lastTs && new Date(row.lastTs).getTime() >= sevenDaysAgo
+    ).length,
+    totalBulbs: rows.reduce((sum, row) => sum + row.totalBulbs, 0),
+    lastActivity,
+  };
+}
+
+function passesFilters(row: LoteGlobalRow, query: GlobalLotesQuery) {
+  if (query.productoId && row.productoId !== query.productoId) return false;
+  if (query.variedadId && row.variedadId !== query.variedadId) return false;
+  if (query.subvariedadId && row.subvariedadId !== query.subvariedadId) {
+    return false;
+  }
+  if (query.tipoProcesoId && row.etapaActualId !== query.tipoProcesoId) {
+    return false;
+  }
+  if (query.servicioId && row.servicioActualId !== query.servicioId) {
+    return false;
+  }
+  if (query.estado === "activo" && !row.isActive) return false;
+  if (query.estado === "inactivo" && row.isActive) return false;
+  if (query.minBulbs !== undefined && row.totalBulbs < query.minBulbs) {
+    return false;
+  }
+  if (query.maxBulbs !== undefined && row.totalBulbs > query.maxBulbs) {
+    return false;
+  }
+
+  const created = row.createdAt ? new Date(row.createdAt) : null;
+  const createdFrom = parseDateBoundary(query.createdFrom);
+  const createdTo = parseDateBoundary(query.createdTo, true);
+  if (createdFrom && (!created || created < createdFrom)) return false;
+  if (createdTo && (!created || created > createdTo)) return false;
+
+  if (query.activity === "con_datos" && row.totalBulbs === 0 && !row.lastTs) {
+    return false;
+  }
+  if (query.activity === "sin_datos" && (row.totalBulbs > 0 || row.lastTs)) {
+    return false;
+  }
+  if (query.activity === "ultimos_7" || query.activity === "ultimos_30") {
+    const days = query.activity === "ultimos_7" ? 7 : 30;
+    const minTime = Date.now() - days * 24 * 60 * 60 * 1000;
+    if (!row.lastTs || new Date(row.lastTs).getTime() < minTime) return false;
+  }
+
+  if (query.search) {
+    const term = normalize(query.search);
+    const haystack = normalize([
+      row.codigoLote,
+      row.id,
+      row.productoNombre,
+      row.variedadNombre,
+      row.variedadTipo,
+      row.subvariedadNombre,
+      row.etapaActual,
+      row.servicioActual,
+    ].join(" "));
+    if (!haystack.includes(term)) return false;
+  }
+
+  return true;
+}
+
+function sortRows(rows: LoteGlobalRow[], query: GlobalLotesQuery) {
+  const direction = query.order === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    let result = 0;
+    switch (query.sort) {
+      case "codigoLote":
+        result = compareNullableText(a.codigoLote, b.codigoLote);
+        break;
+      case "producto":
+        result = compareNullableText(a.productoNombre, b.productoNombre);
+        break;
+      case "variedad":
+        result = compareNullableText(a.variedadNombre, b.variedadNombre);
+        break;
+      case "etapa":
+        result = compareNullableText(a.etapaActual, b.etapaActual);
+        break;
+      case "totalBulbs":
+        result = a.totalBulbs - b.totalBulbs;
+        break;
+      case "lastTs":
+        result = compareNullableDate(a.lastTs, b.lastTs);
+        break;
+      case "estado":
+        result = Number(a.isActive) - Number(b.isActive);
+        break;
+      case "createdAt":
+      default:
+        result = compareNullableDate(a.createdAt, b.createdAt);
+        break;
+    }
+
+    if (result === 0) {
+      result = compareNullableDate(a.createdAt, b.createdAt);
+    }
+    return result * direction;
+  });
+}
+
+export async function getGlobalLotesPayload(
+  query: GlobalLotesQuery,
+  options: { paginate?: boolean } = { paginate: true }
+): Promise<GlobalLotesPayload> {
+  const servicios = await db
+    .select({ id: servicio.id })
+    .from(servicio)
+    .where(eq(servicio.empresaId, query.empresaId));
+  const servicioIds = servicios.map((s) => s.id);
+
+  if (servicioIds.length === 0) {
+    const emptySummary = buildSummary([], 0);
+    return {
+      data: [],
+      total: 0,
+      page: query.page,
+      limit: query.limit,
+      summary: emptySummary,
+      facets: buildFacets([]),
+    };
+  }
+
+  const loteLinks = await db
+    .select({ loteId: loteServicio.loteId })
+    .from(loteServicio)
+    .where(inArray(loteServicio.servicioId, servicioIds));
+  const uniqueLoteIds = [...new Set(loteLinks.map((link) => link.loteId))];
+
+  if (uniqueLoteIds.length === 0) {
+    const emptySummary = buildSummary([], 0);
+    return {
+      data: [],
+      total: 0,
+      page: query.page,
+      limit: query.limit,
+      summary: emptySummary,
+      facets: buildFacets([]),
+    };
+  }
+
+  const [baseRows, statsRows, activeRows, assignmentRows] = await Promise.all([
+    db
+      .select({
+        id: lote.id,
+        codigoLote: lote.codigoLote,
+        createdAt: lote.createdAt,
+        variedadId: lote.variedadId,
+        variedadNombre: variedad.nombre,
+        variedadTipo: variedad.tipo,
+        subvariedadId: lote.subvariedadId,
+        subvariedadNombre: subvariedad.nombre,
+        productoId: producto.id,
+        productoNombre: producto.nombre,
+      })
+      .from(lote)
+      .leftJoin(variedad, eq(variedad.id, lote.variedadId))
+      .leftJoin(subvariedad, eq(subvariedad.id, lote.subvariedadId))
+      .leftJoin(producto, eq(producto.id, variedad.productoId))
+      .where(inArray(lote.id, uniqueLoteIds)),
+    db
+      .select({
+        loteId: loteStats.loteId,
+        totalBulbs: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
+        firstTs: sql<Date | null>`MIN(${loteStats.firstTs})`,
+        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+      })
+      .from(loteStats)
+      .where(inArray(loteStats.loteId, uniqueLoteIds))
+      .groupBy(loteStats.loteId),
+    db
+      .select({ loteId: loteSession.loteId })
+      .from(loteSession)
+      .where(
+        and(inArray(loteSession.loteId, uniqueLoteIds), isNull(loteSession.endTime))
+      ),
+    db
+      .select({
+        loteId: loteServicio.loteId,
+        asignadoAt: loteServicio.asignadoAt,
+        servicioId: servicio.id,
+        servicioNombre: servicio.nombre,
+        tipoProcesoId: tipoProceso.id,
+        tipoProcesoNombre: tipoProceso.nombre,
+      })
+      .from(loteServicio)
+      .innerJoin(servicio, eq(servicio.id, loteServicio.servicioId))
+      .leftJoin(proceso, eq(proceso.id, servicio.procesoId))
+      .leftJoin(tipoProceso, eq(tipoProceso.id, proceso.tipoProcesoId))
+      .where(inArray(loteServicio.loteId, uniqueLoteIds))
+      .orderBy(desc(loteServicio.asignadoAt)),
+  ]);
+
+  const statsByLote = new Map<string, StatsByLote>();
+  for (const row of statsRows) {
+    statsByLote.set(row.loteId, {
+      totalBulbs: Number(row.totalBulbs) || 0,
+      firstTs: row.firstTs,
+      lastTs: row.lastTs,
+    });
+  }
+
+  const activeLoteIds = new Set(activeRows.map((row) => row.loteId));
+  const latestByLote = new Map<string, LatestAssignment>();
+  for (const row of assignmentRows) {
+    if (!latestByLote.has(row.loteId)) {
+      latestByLote.set(row.loteId, {
+        servicioId: row.servicioId,
+        servicioNombre: row.servicioNombre,
+        tipoProcesoId: row.tipoProcesoId,
+        tipoProcesoNombre: row.tipoProcesoNombre,
+      });
+    }
+  }
+
+  const allRows: LoteGlobalRow[] = baseRows.map((row) => {
+    const stats = statsByLote.get(row.id);
+    const latest = latestByLote.get(row.id);
+    return {
+      id: row.id,
+      codigoLote: row.codigoLote,
+      createdAt: toIso(row.createdAt),
+      variedadId: row.variedadId,
+      variedadNombre: row.variedadNombre,
+      variedadTipo: row.variedadTipo,
+      subvariedadId: row.subvariedadId,
+      subvariedadNombre: row.subvariedadNombre,
+      productoId: row.productoId,
+      productoNombre: row.productoNombre,
+      totalBulbs: stats?.totalBulbs ?? 0,
+      firstTs: toIso(stats?.firstTs),
+      lastTs: toIso(stats?.lastTs),
+      isActive: activeLoteIds.has(row.id),
+      etapaActualId: latest?.tipoProcesoId ?? null,
+      etapaActual: latest?.tipoProcesoNombre ?? null,
+      servicioActualId: latest?.servicioId ?? null,
+      servicioActual: latest?.servicioNombre ?? null,
+    };
+  });
+
+  const facets = buildFacets(allRows);
+  const filteredRows = allRows.filter((row) => passesFilters(row, query));
+  const sortedRows = sortRows(filteredRows, query);
+  const total = sortedRows.length;
+  const offset = (query.page - 1) * query.limit;
+  const data = options.paginate === false
+    ? sortedRows
+    : sortedRows.slice(offset, offset + query.limit);
+
+  return {
+    data,
+    total,
+    page: query.page,
+    limit: query.limit,
+    summary: buildSummary(filteredRows, allRows.length),
+    facets,
+  };
+}

--- a/my-project/src/app/app/lotes/page.tsx
+++ b/my-project/src/app/app/lotes/page.tsx
@@ -1,30 +1,115 @@
 "use client";
 
-import React, { useContext, useEffect, useState, useCallback } from "react";
-import { AuthenticationContext } from "@/app/context/AuthContext";
-import { Card, CardContent } from "@/components/ui/card";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import * as XLSX from "xlsx";
+import { AuthenticationContext } from "@/app/context/AuthContext";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
-  Package,
-  Search,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
   ChevronLeft,
   ChevronRight,
+  Download,
+  Filter,
+  Package,
+  Search,
+  SlidersHorizontal,
+  X,
 } from "lucide-react";
 
-// ---------- Types ----------
+type SortField =
+  | "codigoLote"
+  | "producto"
+  | "variedad"
+  | "etapa"
+  | "totalBulbs"
+  | "createdAt"
+  | "lastTs"
+  | "estado";
+type SortOrder = "asc" | "desc";
+type EstadoFilter = "todos" | "activo" | "inactivo";
+type ActivityFilter =
+  | "todos"
+  | "con_datos"
+  | "sin_datos"
+  | "ultimos_7"
+  | "ultimos_30";
 
 interface LoteRow {
   id: string;
   codigoLote: string | null;
-  createdAt: string;
+  createdAt: string | null;
+  variedadId: string | null;
   variedadNombre: string | null;
   variedadTipo: string | null;
+  subvariedadId: string | null;
+  subvariedadNombre: string | null;
+  productoId: string | null;
   productoNombre: string | null;
   totalBulbs: number;
+  firstTs: string | null;
   lastTs: string | null;
   isActive: boolean;
+  etapaActualId: string | null;
   etapaActual: string | null;
+  servicioActualId: string | null;
   servicioActual: string | null;
+}
+
+interface FacetOption {
+  id: string;
+  nombre: string;
+  count: number;
+}
+
+interface VariedadFacetOption extends FacetOption {
+  productoId: string | null;
+  productoNombre: string | null;
+  tipo: string | null;
+}
+
+interface Facets {
+  productos: FacetOption[];
+  variedades: VariedadFacetOption[];
+  subvariedades: Array<FacetOption & { variedadId: string | null }>;
+  etapas: FacetOption[];
+  servicios: Array<FacetOption & { tipoProcesoId: string | null }>;
+}
+
+interface Summary {
+  allTotal: number;
+  total: number;
+  active: number;
+  inactive: number;
+  withData: number;
+  withoutData: number;
+  recent7: number;
+  totalBulbs: number;
+  lastActivity: string | null;
 }
 
 interface LotesResponse {
@@ -32,16 +117,74 @@ interface LotesResponse {
   total: number;
   page: number;
   limit: number;
+  summary: Summary;
+  facets: Facets;
 }
 
-// ---------- Helpers ----------
+interface Filters {
+  search: string;
+  productoId: string;
+  variedadId: string;
+  subvariedadId: string;
+  estado: EstadoFilter;
+  tipoProcesoId: string;
+  servicioId: string;
+  createdFrom: string;
+  createdTo: string;
+  activity: ActivityFilter;
+  minBulbs: string;
+  maxBulbs: string;
+  sort: SortField;
+  order: SortOrder;
+  page: number;
+}
+
+const DEFAULT_FILTERS: Filters = {
+  search: "",
+  productoId: "",
+  variedadId: "",
+  subvariedadId: "",
+  estado: "todos",
+  tipoProcesoId: "",
+  servicioId: "",
+  createdFrom: "",
+  createdTo: "",
+  activity: "todos",
+  minBulbs: "",
+  maxBulbs: "",
+  sort: "createdAt",
+  order: "desc",
+  page: 1,
+};
+
+const EMPTY_FACETS: Facets = {
+  productos: [],
+  variedades: [],
+  subvariedades: [],
+  etapas: [],
+  servicios: [],
+};
+
+const EMPTY_SUMMARY: Summary = {
+  allTotal: 0,
+  total: 0,
+  active: 0,
+  inactive: 0,
+  withData: 0,
+  withoutData: 0,
+  recent7: 0,
+  totalBulbs: 0,
+  lastActivity: null,
+};
+
+const LIMIT = 25;
 
 function formatNumber(n: number): string {
   return n.toLocaleString("es-CL");
 }
 
 function formatDate(iso: string | null): string {
-  if (!iso) return "\u2014";
+  if (!iso) return "-";
   return new Date(iso).toLocaleDateString("es-CL", {
     day: "2-digit",
     month: "2-digit",
@@ -49,222 +192,1032 @@ function formatDate(iso: string | null): string {
   });
 }
 
-function displayLote(lote: Pick<LoteRow, "codigoLote">): string {
-  return lote.codigoLote?.trim() || "Sin código";
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "-";
+  return new Date(iso).toLocaleString("es-CL", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
-// ---------- Main Page ----------
+function displayLote(lote: Pick<LoteRow, "codigoLote">): string {
+  return lote.codigoLote?.trim() || "Sin codigo";
+}
+
+function parseUrlFilters(): Filters {
+  if (typeof window === "undefined") return DEFAULT_FILTERS;
+  const params = new URLSearchParams(window.location.search);
+  const estado = params.get("estado");
+  const activity = params.get("activity");
+  const sort = params.get("sort");
+  const order = params.get("order");
+  const page = Math.max(1, Number(params.get("page") ?? "1") || 1);
+
+  return {
+    ...DEFAULT_FILTERS,
+    search: params.get("search") ?? "",
+    productoId: params.get("productoId") ?? "",
+    variedadId: params.get("variedadId") ?? "",
+    subvariedadId: params.get("subvariedadId") ?? "",
+    estado:
+      estado === "activo" || estado === "inactivo" || estado === "todos"
+        ? estado
+        : "todos",
+    tipoProcesoId: params.get("tipoProcesoId") ?? "",
+    servicioId: params.get("servicioId") ?? "",
+    createdFrom: params.get("createdFrom") ?? "",
+    createdTo: params.get("createdTo") ?? "",
+    activity:
+      activity === "con_datos" ||
+      activity === "sin_datos" ||
+      activity === "ultimos_7" ||
+      activity === "ultimos_30" ||
+      activity === "todos"
+        ? activity
+        : "todos",
+    minBulbs: params.get("minBulbs") ?? "",
+    maxBulbs: params.get("maxBulbs") ?? "",
+    sort:
+      sort === "codigoLote" ||
+      sort === "producto" ||
+      sort === "variedad" ||
+      sort === "etapa" ||
+      sort === "totalBulbs" ||
+      sort === "createdAt" ||
+      sort === "lastTs" ||
+      sort === "estado"
+        ? sort
+        : "createdAt",
+    order: order === "asc" ? "asc" : "desc",
+    page,
+  };
+}
+
+function setParamIfValue(params: URLSearchParams, key: string, value: string) {
+  if (value) params.set(key, value);
+}
+
+function filtersToUrlParams(filters: Filters) {
+  const params = new URLSearchParams();
+  setParamIfValue(params, "search", filters.search);
+  setParamIfValue(params, "productoId", filters.productoId);
+  setParamIfValue(params, "variedadId", filters.variedadId);
+  setParamIfValue(params, "subvariedadId", filters.subvariedadId);
+  if (filters.estado !== "todos") params.set("estado", filters.estado);
+  setParamIfValue(params, "tipoProcesoId", filters.tipoProcesoId);
+  setParamIfValue(params, "servicioId", filters.servicioId);
+  setParamIfValue(params, "createdFrom", filters.createdFrom);
+  setParamIfValue(params, "createdTo", filters.createdTo);
+  if (filters.activity !== "todos") params.set("activity", filters.activity);
+  setParamIfValue(params, "minBulbs", filters.minBulbs);
+  setParamIfValue(params, "maxBulbs", filters.maxBulbs);
+  if (filters.sort !== "createdAt") params.set("sort", filters.sort);
+  if (filters.order !== "desc") params.set("order", filters.order);
+  if (filters.page > 1) params.set("page", String(filters.page));
+  return params;
+}
+
+function getStatus(row: LoteRow) {
+  if (row.isActive) {
+    return {
+      label: "Activo",
+      className: "border-emerald-500/30 bg-emerald-500/10 text-emerald-300",
+    };
+  }
+  if (row.totalBulbs === 0 && !row.lastTs) {
+    return {
+      label: "Sin datos",
+      className: "border-slate-700 bg-slate-800/70 text-slate-400",
+    };
+  }
+  return {
+    label: "Inactivo",
+    className: "border-amber-500/25 bg-amber-500/10 text-amber-300",
+  };
+}
+
+function csvEscape(value: unknown) {
+  const text = String(value ?? "");
+  if (!/[",\n]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
 
 export default function LotesPage() {
+  const pathname = usePathname();
   const { data, loading: authLoading } = useContext(AuthenticationContext);
 
+  const [ready, setReady] = useState(false);
   const [lotes, setLotes] = useState<LoteRow[]>([]);
   const [total, setTotal] = useState(0);
-  const [page, setPage] = useState(1);
+  const [facets, setFacets] = useState<Facets>(EMPTY_FACETS);
+  const [summary, setSummary] = useState<Summary>(EMPTY_SUMMARY);
+  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [searchInput, setSearchInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
 
-  const limit = 25;
-  const totalPages = Math.ceil(total / limit);
+  const totalPages = Math.max(1, Math.ceil(total / LIMIT));
 
-  // Debounce search
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(search);
-      setPage(1);
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+    const urlFilters = parseUrlFilters();
+    setFilters(urlFilters);
+    setSearchInput(urlFilters.search);
+    setReady(true);
+  }, []);
 
-  // Fetch lotes
-  const fetchLotes = useCallback(async () => {
-    if (!data?.empresaId) return;
+  useEffect(() => {
+    if (!ready) return;
+    const timer = window.setTimeout(() => {
+      setFilters((prev) =>
+        prev.search === searchInput
+          ? prev
+          : { ...prev, search: searchInput, page: 1 }
+      );
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [ready, searchInput]);
+
+  useEffect(() => {
+    if (!ready) return;
+    const params = filtersToUrlParams(filters);
+    const nextUrl = params.toString() ? `${pathname}?${params}` : pathname;
+    window.history.replaceState(null, "", nextUrl);
+  }, [filters, pathname, ready]);
+
+  const buildApiParams = useCallback(
+    (forExport = false) => {
+      const params = filtersToUrlParams(filters);
+      params.set("empresaId", data?.empresaId ?? "");
+      if (!forExport) {
+        params.set("page", String(filters.page));
+        params.set("limit", String(LIMIT));
+      } else {
+        params.delete("page");
+      }
+      return params;
+    },
+    [data?.empresaId, filters]
+  );
+
+  const apiQuery = useMemo(() => {
+    if (!ready || !data?.empresaId) return "";
+    return buildApiParams().toString();
+  }, [buildApiParams, data?.empresaId, ready]);
+
+  useEffect(() => {
+    if (!apiQuery) return;
     setLoading(true);
     setError(null);
 
-    const params = new URLSearchParams({
-      empresaId: data.empresaId,
-      page: page.toString(),
-      limit: limit.toString(),
-    });
-    if (debouncedSearch) params.set("search", debouncedSearch);
+    fetch(`/api/lotes/global?${apiQuery}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Error al cargar los lotes");
+        return res.json() as Promise<LotesResponse>;
+      })
+      .then((json) => {
+        setLotes(json.data);
+        setTotal(json.total);
+        setFacets(json.facets ?? EMPTY_FACETS);
+        setSummary(json.summary ?? EMPTY_SUMMARY);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Error desconocido");
+      })
+      .finally(() => setLoading(false));
+  }, [apiQuery]);
 
-    try {
-      const res = await fetch(`/api/lotes/global?${params.toString()}`);
-      if (!res.ok) throw new Error("Error al cargar los lotes");
-      const json: LotesResponse = await res.json();
-      setLotes(json.data);
-      setTotal(json.total);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Error desconocido");
-    } finally {
-      setLoading(false);
+  const updateFilters = useCallback((patch: Partial<Filters>) => {
+    setFilters((prev) => ({ ...prev, ...patch, page: 1 }));
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setSearchInput("");
+    setFilters(DEFAULT_FILTERS);
+  }, []);
+
+  const productById = useMemo(
+    () => new Map(facets.productos.map((item) => [item.id, item])),
+    [facets.productos]
+  );
+  const varietyById = useMemo(
+    () => new Map(facets.variedades.map((item) => [item.id, item])),
+    [facets.variedades]
+  );
+  const subvarietyById = useMemo(
+    () => new Map(facets.subvariedades.map((item) => [item.id, item])),
+    [facets.subvariedades]
+  );
+  const etapaById = useMemo(
+    () => new Map(facets.etapas.map((item) => [item.id, item])),
+    [facets.etapas]
+  );
+  const serviceById = useMemo(
+    () => new Map(facets.servicios.map((item) => [item.id, item])),
+    [facets.servicios]
+  );
+
+  const visibleVariedades = useMemo(() => {
+    if (!filters.productoId) return facets.variedades;
+    return facets.variedades.filter(
+      (item) => item.productoId === filters.productoId
+    );
+  }, [facets.variedades, filters.productoId]);
+
+  const visibleSubvariedades = useMemo(() => {
+    if (!filters.variedadId) return facets.subvariedades;
+    return facets.subvariedades.filter(
+      (item) => item.variedadId === filters.variedadId
+    );
+  }, [facets.subvariedades, filters.variedadId]);
+
+  const visibleServicios = useMemo(() => {
+    if (!filters.tipoProcesoId) return facets.servicios;
+    return facets.servicios.filter(
+      (item) => item.tipoProcesoId === filters.tipoProcesoId
+    );
+  }, [facets.servicios, filters.tipoProcesoId]);
+
+  const activeChips = useMemo(() => {
+    const chips: Array<{ key: string; label: string; onRemove: () => void }> = [];
+    if (filters.search) {
+      chips.push({
+        key: "search",
+        label: `Busqueda: ${filters.search}`,
+        onRemove: () => {
+          setSearchInput("");
+          updateFilters({ search: "" });
+        },
+      });
     }
-  }, [data?.empresaId, page, debouncedSearch]);
+    if (filters.productoId) {
+      chips.push({
+        key: "producto",
+        label: productById.get(filters.productoId)?.nombre ?? "Producto",
+        onRemove: () =>
+          updateFilters({ productoId: "", variedadId: "", subvariedadId: "" }),
+      });
+    }
+    if (filters.variedadId) {
+      chips.push({
+        key: "variedad",
+        label: varietyById.get(filters.variedadId)?.nombre ?? "Variedad",
+        onRemove: () => updateFilters({ variedadId: "", subvariedadId: "" }),
+      });
+    }
+    if (filters.subvariedadId) {
+      chips.push({
+        key: "subvariedad",
+        label:
+          subvarietyById.get(filters.subvariedadId)?.nombre ?? "Subvariedad",
+        onRemove: () => updateFilters({ subvariedadId: "" }),
+      });
+    }
+    if (filters.tipoProcesoId) {
+      chips.push({
+        key: "etapa",
+        label: etapaById.get(filters.tipoProcesoId)?.nombre ?? "Etapa",
+        onRemove: () => updateFilters({ tipoProcesoId: "", servicioId: "" }),
+      });
+    }
+    if (filters.servicioId) {
+      chips.push({
+        key: "servicio",
+        label: serviceById.get(filters.servicioId)?.nombre ?? "Servicio",
+        onRemove: () => updateFilters({ servicioId: "" }),
+      });
+    }
+    if (filters.createdFrom || filters.createdTo) {
+      chips.push({
+        key: "created",
+        label: `Creado ${filters.createdFrom || "..."} - ${
+          filters.createdTo || "..."
+        }`,
+        onRemove: () => updateFilters({ createdFrom: "", createdTo: "" }),
+      });
+    }
+    if (filters.minBulbs || filters.maxBulbs) {
+      chips.push({
+        key: "bulbs",
+        label: `Bulbos ${filters.minBulbs || "0"} - ${
+          filters.maxBulbs || "sin limite"
+        }`,
+        onRemove: () => updateFilters({ minBulbs: "", maxBulbs: "" }),
+      });
+    }
+    return chips;
+  }, [
+    etapaById,
+    filters,
+    productById,
+    serviceById,
+    subvarietyById,
+    updateFilters,
+    varietyById,
+  ]);
 
-  useEffect(() => {
-    fetchLotes();
-  }, [fetchLotes]);
+  const hasActiveFilters =
+    activeChips.length > 0 ||
+    filters.estado !== "todos" ||
+    filters.activity !== "todos";
 
-  if (authLoading) {
+  const setQuickFilter = (key: string) => {
+    if (key === "todos") {
+      updateFilters({ estado: "todos", activity: "todos" });
+    }
+    if (key === "activos") {
+      updateFilters({ estado: "activo", activity: "todos" });
+    }
+    if (key === "con_datos") {
+      updateFilters({ estado: "todos", activity: "con_datos" });
+    }
+    if (key === "sin_datos") {
+      updateFilters({ estado: "todos", activity: "sin_datos" });
+    }
+    if (key === "ultimos_7") {
+      updateFilters({ estado: "todos", activity: "ultimos_7" });
+    }
+  };
+
+  const currentQuickFilter = useMemo(() => {
+    if (filters.estado === "activo" && filters.activity === "todos") {
+      return "activos";
+    }
+    if (filters.estado === "todos" && filters.activity === "con_datos") {
+      return "con_datos";
+    }
+    if (filters.estado === "todos" && filters.activity === "sin_datos") {
+      return "sin_datos";
+    }
+    if (filters.estado === "todos" && filters.activity === "ultimos_7") {
+      return "ultimos_7";
+    }
+    if (filters.estado === "todos" && filters.activity === "todos") {
+      return "todos";
+    }
+    return "";
+  }, [filters.activity, filters.estado]);
+
+  const handleSort = (field: SortField) => {
+    setFilters((prev) => {
+      if (prev.sort === field) {
+        return {
+          ...prev,
+          order: prev.order === "asc" ? "desc" : "asc",
+          page: 1,
+        };
+      }
+      const defaultOrder =
+        field === "codigoLote" || field === "producto" || field === "variedad"
+          ? "asc"
+          : "desc";
+      return { ...prev, sort: field, order: defaultOrder, page: 1 };
+    });
+  };
+
+  const fetchExportRows = async () => {
+    setExporting(true);
+    try {
+      const params = buildApiParams(true);
+      const res = await fetch(`/api/lotes/global/export?${params.toString()}`);
+      if (!res.ok) throw new Error("Error al exportar lotes");
+      const json: { data: LoteRow[] } = await res.json();
+      return json.data;
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const toExportRows = (rows: LoteRow[]) =>
+    rows.map((row) => ({
+      Codigo: displayLote(row),
+      Producto: row.productoNombre ?? "",
+      Variedad: row.variedadNombre ?? "",
+      Subvariedad: row.subvariedadNombre ?? "",
+      Etapa: row.etapaActual ?? "",
+      Servicio: row.servicioActual ?? "",
+      Estado: getStatus(row).label,
+      Bulbos: row.totalBulbs,
+      Creado: formatDate(row.createdAt),
+      "Primera actividad": formatDateTime(row.firstTs),
+      "Ultima actividad": formatDateTime(row.lastTs),
+      ID: row.id,
+    }));
+
+  const exportCsv = async () => {
+    try {
+      const rows = toExportRows(await fetchExportRows());
+      const headers = Object.keys(rows[0] ?? { Codigo: "" });
+      const csv = [
+        headers.join(","),
+        ...rows.map((row) =>
+          headers.map((header) => csvEscape(row[header as keyof typeof row])).join(",")
+        ),
+      ].join("\n");
+      const blob = new Blob(["\ufeff", csv], {
+        type: "text/csv;charset=utf-8",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "lotes-filtrados.csv";
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error al exportar CSV");
+    }
+  };
+
+  const exportXlsx = async () => {
+    try {
+      const rows = toExportRows(await fetchExportRows());
+      const workbook = XLSX.utils.book_new();
+      const worksheet = XLSX.utils.json_to_sheet(rows);
+      XLSX.utils.book_append_sheet(workbook, worksheet, "Lotes");
+      XLSX.writeFile(workbook, "lotes-filtrados.xlsx");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error al exportar XLSX");
+    }
+  };
+
+  const SortButton = ({
+    field,
+    children,
+    className = "",
+  }: {
+    field: SortField;
+    children: React.ReactNode;
+    className?: string;
+  }) => {
+    const active = filters.sort === field;
+    const Icon = !active ? ArrowUpDown : filters.order === "asc" ? ArrowUp : ArrowDown;
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-slate-400 text-sm animate-pulse">Cargando...</div>
+      <button
+        type="button"
+        onClick={() => handleSort(field)}
+        className={`inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-slate-500 transition-colors hover:text-slate-300 ${className}`}
+      >
+        {children}
+        <Icon className={`h-3.5 w-3.5 ${active ? "text-cyan-300" : ""}`} />
+      </button>
+    );
+  };
+
+  if (authLoading || !ready) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-sm text-slate-400 animate-pulse">Cargando...</div>
       </div>
     );
   }
 
   if (!data) {
     return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-slate-400 text-sm">No estas autenticado.</div>
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="text-sm text-slate-400">No estas autenticado.</div>
       </div>
     );
   }
 
+  const quickFilters = [
+    { key: "todos", label: "Todos", count: summary.allTotal },
+    { key: "activos", label: "Activos", count: summary.active },
+    { key: "con_datos", label: "Con datos", count: summary.withData },
+    { key: "sin_datos", label: "Sin datos", count: summary.withoutData },
+    { key: "ultimos_7", label: "Ultimos 7 dias", count: summary.recent7 },
+  ];
+
   return (
-    <div className="w-full max-w-7xl mx-auto p-4 md:p-6 lg:p-8 space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight text-white">Lotes</h1>
-        <p className="text-slate-400 mt-1">
-          {data.empresaNombre ?? ""}
-        </p>
+    <div className="mx-auto w-full max-w-7xl space-y-5 p-4 md:p-6 lg:p-8">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-white">Lotes</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            {data.empresaNombre ?? "Empresa"} · vista operacional
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={exporting || summary.total === 0}
+            onClick={exportCsv}
+            className="border-white/10 bg-slate-900/40 text-slate-300 hover:bg-slate-800 hover:text-white"
+          >
+            <Download className="h-4 w-4" />
+            CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={exporting || summary.total === 0}
+            onClick={exportXlsx}
+            className="border-white/10 bg-slate-900/40 text-slate-300 hover:bg-slate-800 hover:text-white"
+          >
+            <Download className="h-4 w-4" />
+            XLSX
+          </Button>
+        </div>
       </div>
 
-      {/* Search bar */}
-      <div className="relative max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
-        <input
-          type="text"
-          placeholder="Buscar por código de lote..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full pl-10 pr-4 py-2.5 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500/40 focus:ring-1 focus:ring-cyan-500/20 transition-colors"
-        />
+      <div className="grid gap-3 rounded-lg border border-white/10 bg-slate-900/35 p-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-slate-500">Lotes</p>
+          <p className="mt-1 text-xl font-semibold text-white">
+            {formatNumber(summary.total)}
+            <span className="ml-2 text-xs font-normal text-slate-500">
+              de {formatNumber(summary.allTotal)}
+            </span>
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-slate-500">Activos</p>
+          <p className="mt-1 text-xl font-semibold text-emerald-300">
+            {formatNumber(summary.active)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-slate-500">Bulbos</p>
+          <p className="mt-1 text-xl font-semibold text-cyan-300">
+            {formatNumber(summary.totalBulbs)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wider text-slate-500">
+            Ultima actividad
+          </p>
+          <p className="mt-1 truncate text-sm font-medium text-slate-300">
+            {formatDateTime(summary.lastActivity)}
+          </p>
+        </div>
       </div>
 
-      {/* Error */}
+      <div className="space-y-3 rounded-lg border border-white/10 bg-slate-950/25 p-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <Input
+              type="text"
+              placeholder="Buscar codigo, producto, variedad, etapa o servicio..."
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              className="h-10 border-white/10 bg-slate-900/60 pl-10 text-white placeholder:text-slate-500 focus-visible:ring-cyan-500"
+            />
+          </div>
+
+          <div className="flex gap-2 overflow-x-auto pb-1 lg:pb-0">
+            {quickFilters.map((item) => {
+              const active = currentQuickFilter === item.key;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setQuickFilter(item.key)}
+                  className={`shrink-0 rounded-md border px-3 py-2 text-xs font-medium transition-colors ${
+                    active
+                      ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-200"
+                      : "border-white/10 bg-slate-900/40 text-slate-400 hover:border-white/20 hover:text-white"
+                  }`}
+                >
+                  {item.label}
+                  <span className="ml-2 text-slate-500">
+                    {formatNumber(item.count)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className="h-10 shrink-0 border-white/10 bg-slate-900/50 text-slate-200 hover:bg-slate-800 hover:text-white"
+              >
+                <SlidersHorizontal className="h-4 w-4" />
+                Filtros
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-[min(92vw,560px)] border-white/10 bg-slate-900 p-4 text-white shadow-2xl"
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold">Filtros avanzados</p>
+                  <p className="text-xs text-slate-500">
+                    Refina por variedad, proceso, fechas y volumen.
+                  </p>
+                </div>
+                <Filter className="h-4 w-4 text-slate-500" />
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Producto
+                  </label>
+                  <Select
+                    value={filters.productoId || "all"}
+                    onValueChange={(value) =>
+                      updateFilters({
+                        productoId: value === "all" ? "" : value,
+                        variedadId: "",
+                        subvariedadId: "",
+                      })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="all">Todos</SelectItem>
+                      {facets.productos.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.nombre} ({item.count})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Variedad
+                  </label>
+                  <Select
+                    value={filters.variedadId || "all"}
+                    onValueChange={(value) =>
+                      updateFilters({
+                        variedadId: value === "all" ? "" : value,
+                        subvariedadId: "",
+                      })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="all">Todas</SelectItem>
+                      {visibleVariedades.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.tipo ? `${item.tipo} · ` : ""}
+                          {item.nombre} ({item.count})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Subvariedad
+                  </label>
+                  <Select
+                    value={filters.subvariedadId || "all"}
+                    onValueChange={(value) =>
+                      updateFilters({
+                        subvariedadId: value === "all" ? "" : value,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="all">Todas</SelectItem>
+                      {visibleSubvariedades.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.nombre} ({item.count})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Estado
+                  </label>
+                  <Select
+                    value={filters.estado}
+                    onValueChange={(value) =>
+                      updateFilters({ estado: value as EstadoFilter })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="todos">Todos</SelectItem>
+                      <SelectItem value="activo">Activo</SelectItem>
+                      <SelectItem value="inactivo">Inactivo</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Etapa actual
+                  </label>
+                  <Select
+                    value={filters.tipoProcesoId || "all"}
+                    onValueChange={(value) =>
+                      updateFilters({
+                        tipoProcesoId: value === "all" ? "" : value,
+                        servicioId: "",
+                      })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="all">Todas</SelectItem>
+                      {facets.etapas.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.nombre} ({item.count})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Servicio actual
+                  </label>
+                  <Select
+                    value={filters.servicioId || "all"}
+                    onValueChange={(value) =>
+                      updateFilters({ servicioId: value === "all" ? "" : value })
+                    }
+                  >
+                    <SelectTrigger className="border-white/10 bg-slate-800 text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent className="border-white/10 bg-slate-900 text-white">
+                      <SelectItem value="all">Todos</SelectItem>
+                      {visibleServicios.map((item) => (
+                        <SelectItem key={item.id} value={item.id}>
+                          {item.nombre} ({item.count})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Creado desde
+                  </label>
+                  <Input
+                    type="date"
+                    value={filters.createdFrom}
+                    onChange={(event) =>
+                      updateFilters({ createdFrom: event.target.value })
+                    }
+                    className="border-white/10 bg-slate-800 text-white focus-visible:ring-cyan-500"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Creado hasta
+                  </label>
+                  <Input
+                    type="date"
+                    value={filters.createdTo}
+                    onChange={(event) =>
+                      updateFilters({ createdTo: event.target.value })
+                    }
+                    className="border-white/10 bg-slate-800 text-white focus-visible:ring-cyan-500"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Min. bulbos
+                  </label>
+                  <Input
+                    inputMode="numeric"
+                    value={filters.minBulbs}
+                    onChange={(event) =>
+                      updateFilters({ minBulbs: event.target.value })
+                    }
+                    placeholder="0"
+                    className="border-white/10 bg-slate-800 text-white placeholder:text-slate-500 focus-visible:ring-cyan-500"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-slate-400">
+                    Max. bulbos
+                  </label>
+                  <Input
+                    inputMode="numeric"
+                    value={filters.maxBulbs}
+                    onChange={(event) =>
+                      updateFilters({ maxBulbs: event.target.value })
+                    }
+                    placeholder="Sin limite"
+                    className="border-white/10 bg-slate-800 text-white placeholder:text-slate-500 focus-visible:ring-cyan-500"
+                  />
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          {hasActiveFilters && (
+            <Button
+              variant="ghost"
+              className="h-10 shrink-0 text-slate-400 hover:bg-white/5 hover:text-white"
+              onClick={clearFilters}
+            >
+              Limpiar
+            </Button>
+          )}
+        </div>
+
+        {(activeChips.length > 0 ||
+          filters.estado !== "todos" ||
+          filters.activity !== "todos") && (
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {filters.estado !== "todos" && (
+              <Badge className="shrink-0 gap-1 border-cyan-500/25 bg-cyan-500/10 text-cyan-200">
+                {filters.estado === "activo" ? "Activo" : "Inactivo"}
+                <button onClick={() => updateFilters({ estado: "todos" })}>
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            )}
+            {filters.activity !== "todos" && (
+              <Badge className="shrink-0 gap-1 border-cyan-500/25 bg-cyan-500/10 text-cyan-200">
+                {filters.activity === "con_datos" && "Con datos"}
+                {filters.activity === "sin_datos" && "Sin datos"}
+                {filters.activity === "ultimos_7" && "Ultimos 7 dias"}
+                {filters.activity === "ultimos_30" && "Ultimos 30 dias"}
+                <button onClick={() => updateFilters({ activity: "todos" })}>
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            )}
+            {activeChips.map((chip) => (
+              <Badge
+                key={chip.key}
+                className="shrink-0 gap-1 border-white/10 bg-slate-800/80 text-slate-300"
+              >
+                {chip.label}
+                <button onClick={chip.onRemove}>
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
       {error && (
-        <div className="p-4 rounded-lg bg-red-950/20 border border-red-500/20 text-red-400 text-sm">
+        <div className="rounded-lg border border-red-500/20 bg-red-950/20 p-4 text-sm text-red-300">
           {error}
         </div>
       )}
 
-      {/* Loading skeleton */}
       {loading && (
-        <Card className="bg-slate-900/40 border-white/10">
+        <Card className="border-white/10 bg-slate-900/40">
           <CardContent className="p-0">
-            <div className="space-y-0">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-14 border-b border-white/5 animate-pulse bg-slate-900/20"
-                />
-              ))}
-            </div>
+            {Array.from({ length: 8 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-14 animate-pulse border-b border-white/5 bg-slate-900/20"
+              />
+            ))}
           </CardContent>
         </Card>
       )}
 
-      {/* Table */}
       {!loading && lotes.length > 0 && (
-        <Card className="bg-slate-900/40 border-white/10">
+        <Card className="overflow-hidden border-white/10 bg-slate-900/40">
           <CardContent className="p-0">
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-white/5">
-                    <th className="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">
-                      Codigo lote
+            <div className="max-h-[68vh] overflow-auto">
+              <table className="w-full min-w-[980px] text-sm">
+                <thead className="sticky top-0 z-10 bg-slate-950/95 backdrop-blur">
+                  <tr className="border-b border-white/10">
+                    <th className="px-5 py-3 text-left">
+                      <SortButton field="codigoLote">Codigo lote</SortButton>
                     </th>
-                    <th className="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider hidden sm:table-cell">
-                      Variedad
+                    <th className="px-5 py-3 text-left">
+                      <SortButton field="variedad">Variedad</SortButton>
                     </th>
-                    <th className="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider hidden md:table-cell">
-                      Producto
+                    <th className="px-5 py-3 text-left">
+                      <SortButton field="producto">Producto</SortButton>
                     </th>
-                    <th className="text-left px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider hidden lg:table-cell">
-                      Etapa Actual
+                    <th className="px-5 py-3 text-left">
+                      <SortButton field="etapa">Etapa</SortButton>
                     </th>
-                    <th className="text-right px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider">
-                      Bulbos
+                    <th className="px-5 py-3 text-right">
+                      <SortButton field="totalBulbs" className="ml-auto">
+                        Bulbos
+                      </SortButton>
                     </th>
-                    <th className="text-right px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider hidden md:table-cell">
-                      Creado
+                    <th className="px-5 py-3 text-right">
+                      <SortButton field="lastTs" className="ml-auto">
+                        Ultima actividad
+                      </SortButton>
                     </th>
-                    <th className="text-center px-5 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider w-20">
-                      Estado
+                    <th className="px-5 py-3 text-right">
+                      <SortButton field="createdAt" className="ml-auto">
+                        Creado
+                      </SortButton>
+                    </th>
+                    <th className="px-5 py-3 text-center">
+                      <SortButton field="estado">Estado</SortButton>
                     </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
-                  {lotes.map((l) => (
-                    <tr
-                      key={l.id}
-                      className="hover:bg-white/[0.02] transition-colors group"
-                    >
-                      <td className="px-5 py-3">
-                        <Link
-                          href={`/app/lotes/${l.id}`}
-                          className="text-slate-200 hover:text-cyan-400 transition-colors font-medium font-mono text-xs"
-                        >
-                          {displayLote(l)}
-                        </Link>
-                      </td>
-                      <td className="px-5 py-3 text-slate-400 hidden sm:table-cell">
-                        {l.variedadNombre ? (
-                          <span>
-                            {l.variedadTipo && (
-                              <span className="text-slate-600 text-xs">{l.variedadTipo} › </span>
+                  {lotes.map((loteRow) => {
+                    const status = getStatus(loteRow);
+                    return (
+                      <tr
+                        key={loteRow.id}
+                        className="group transition-colors hover:bg-white/[0.025]"
+                      >
+                        <td className="px-5 py-4">
+                          <Link
+                            href={`/app/lotes/${loteRow.id}`}
+                            className="font-mono text-xs font-medium text-slate-100 transition-colors hover:text-cyan-300"
+                          >
+                            {displayLote(loteRow)}
+                          </Link>
+                          <p className="mt-1 max-w-[180px] truncate text-[11px] text-slate-600">
+                            {loteRow.id}
+                          </p>
+                        </td>
+                        <td className="px-5 py-4 text-slate-300">
+                          {loteRow.variedadNombre ? (
+                            <div className="space-y-1">
+                              <div>
+                                {loteRow.variedadTipo && (
+                                  <span className="mr-1 text-xs text-slate-500">
+                                    {loteRow.variedadTipo}
+                                  </span>
+                                )}
+                                {loteRow.variedadNombre}
+                              </div>
+                              {loteRow.subvariedadNombre && (
+                                <p className="text-xs text-slate-500">
+                                  {loteRow.subvariedadNombre}
+                                </p>
+                              )}
+                            </div>
+                          ) : (
+                            <span className="text-slate-600">-</span>
+                          )}
+                        </td>
+                        <td className="px-5 py-4 text-slate-400">
+                          {loteRow.productoNombre ?? (
+                            <span className="text-slate-600">-</span>
+                          )}
+                        </td>
+                        <td className="px-5 py-4">
+                          <div className="space-y-1">
+                            {loteRow.etapaActual ? (
+                              <Badge className="border-cyan-500/20 bg-cyan-500/10 text-cyan-300">
+                                {loteRow.etapaActual}
+                              </Badge>
+                            ) : (
+                              <span className="text-xs text-slate-600">-</span>
                             )}
-                            {l.variedadNombre}
+                            {loteRow.servicioActual && (
+                              <p className="text-xs text-slate-500">
+                                {loteRow.servicioActual}
+                              </p>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-5 py-4 text-right">
+                          <span className="font-semibold text-cyan-200">
+                            {formatNumber(loteRow.totalBulbs)}
                           </span>
-                        ) : (
-                          <span className="text-slate-600">-</span>
-                        )}
-                      </td>
-                      <td className="px-5 py-3 text-slate-400 hidden md:table-cell">
-                        {l.productoNombre ?? (
-                          <span className="text-slate-600">-</span>
-                        )}
-                      </td>
-                      <td className="px-5 py-3 hidden lg:table-cell">
-                        {l.etapaActual ? (
-                          <span className="text-xs px-2 py-0.5 rounded-full border border-cyan-500/20 bg-cyan-950/30 text-cyan-400">
-                            {l.etapaActual}
-                          </span>
-                        ) : (
-                          <span className="text-slate-600 text-xs">-</span>
-                        )}
-                      </td>
-                      <td className="px-5 py-3 text-right">
-                        <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-emerald-400 font-semibold">
-                          {formatNumber(l.totalBulbs)}
-                        </span>
-                      </td>
-                      <td className="px-5 py-3 text-right text-slate-500 hidden md:table-cell">
-                        {formatDate(l.createdAt)}
-                      </td>
-                      <td className="px-5 py-3 text-center">
-                        {l.isActive ? (
-                          <span className="inline-flex items-center gap-1.5 text-xs text-emerald-400">
-                            <span className="relative flex h-2 w-2">
-                              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-                            </span>
-                            Activo
-                          </span>
-                        ) : (
-                          <span className="text-xs text-slate-600">
-                            Inactivo
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
+                        </td>
+                        <td className="px-5 py-4 text-right text-slate-400">
+                          {formatDateTime(loteRow.lastTs)}
+                        </td>
+                        <td className="px-5 py-4 text-right text-slate-500">
+                          {formatDate(loteRow.createdAt)}
+                        </td>
+                        <td className="px-5 py-4 text-center">
+                          <Badge className={status.className}>
+                            {status.label}
+                          </Badge>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -272,45 +1225,59 @@ export default function LotesPage() {
         </Card>
       )}
 
-      {/* Pagination */}
-      {!loading && totalPages > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-xs text-slate-500">
-            Mostrando {(page - 1) * limit + 1}-
-            {Math.min(page * limit, total)} de {total} lotes
+      {!loading && lotes.length === 0 && !error && (
+        <div className="rounded-lg border border-white/10 bg-slate-900/30 py-16 text-center text-slate-500">
+          <Package className="mx-auto mb-3 h-10 w-10 text-slate-700" />
+          <p className="text-lg font-medium text-slate-300">
+            No se encontraron lotes
           </p>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page === 1}
-              className="p-2 rounded-lg border border-white/10 text-slate-400 hover:text-white hover:border-white/20 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </button>
-            <span className="text-sm text-slate-400 px-2">
-              {page} / {totalPages}
-            </span>
-            <button
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages}
-              className="p-2 rounded-lg border border-white/10 text-slate-400 hover:text-white hover:border-white/20 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </button>
-          </div>
+          <p className="mt-1 text-sm">
+            {hasActiveFilters
+              ? "Ajusta la busqueda o limpia los filtros activos."
+              : "No hay lotes registrados para esta empresa."}
+          </p>
         </div>
       )}
 
-      {/* Empty state */}
-      {!loading && lotes.length === 0 && !error && (
-        <div className="text-center py-20 text-slate-500">
-          <Package className="w-10 h-10 mx-auto mb-3 text-slate-700" />
-          <p className="text-lg font-medium">No se encontraron lotes</p>
-          <p className="text-sm mt-1">
-            {debouncedSearch
-              ? `No hay lotes que coincidan con "${debouncedSearch}".`
-              : "No hay lotes registrados para esta empresa."}
+      {!loading && totalPages > 1 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-slate-500">
+            Mostrando {(filters.page - 1) * LIMIT + 1}-
+            {Math.min(filters.page * LIMIT, total)} de {formatNumber(total)} lotes
           </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() =>
+                setFilters((prev) => ({
+                  ...prev,
+                  page: Math.max(1, prev.page - 1),
+                }))
+              }
+              disabled={filters.page === 1}
+              className="border-white/10 bg-slate-900/40 text-slate-400 hover:bg-slate-800 hover:text-white"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="min-w-20 text-center text-sm text-slate-400">
+              {filters.page} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() =>
+                setFilters((prev) => ({
+                  ...prev,
+                  page: Math.min(totalPages, prev.page + 1),
+                }))
+              }
+              disabled={filters.page === totalPages}
+              className="border-white/10 bg-slate-900/40 text-slate-400 hover:bg-slate-800 hover:text-white"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/page.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Search, X } from "lucide-react";
 
 interface Lote {
   id: string;
@@ -44,6 +45,8 @@ interface Producto {
   variedades: Variedad[];
 }
 
+type StatusFilter = "todos" | "activo" | "inactivo";
+
 function displayLote(lote: Pick<Lote, "codigoLote">): string {
   return lote.codigoLote?.trim() || "Sin código";
 }
@@ -60,6 +63,9 @@ export default function LotesPage() {
   const [productos, setProductos] = useState<Producto[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [productoFilter, setProductoFilter] = useState("");
+  const [variedadFilter, setVariedadFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("todos");
 
   // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -95,13 +101,51 @@ export default function LotesPage() {
       .finally(() => setLoading(false));
   }, [servicioId]);
 
+  const productoOptions = useMemo(() => {
+    return Array.from(
+      new Set(lotes.map((l) => l.productoNombre).filter(Boolean))
+    ) as string[];
+  }, [lotes]);
+
+  const variedadOptions = useMemo(() => {
+    return lotes
+      .filter((lote) => !productoFilter || lote.productoNombre === productoFilter)
+      .filter((lote) => lote.variedadId && lote.variedadNombre)
+      .reduce<Array<{ id: string; nombre: string; tipo?: string | null }>>(
+        (acc, lote) => {
+          if (!lote.variedadId || !lote.variedadNombre) return acc;
+          if (acc.some((item) => item.id === lote.variedadId)) return acc;
+          acc.push({
+            id: lote.variedadId,
+            nombre: lote.variedadNombre,
+            tipo: lote.variedadTipo,
+          });
+          return acc;
+        },
+        []
+      );
+  }, [lotes, productoFilter]);
+
   const filteredLotes = useMemo(() => {
     const term = search.toLowerCase().trim();
-    if (!term) return lotes;
-    return lotes.filter(
-      (l) => (l.codigoLote ?? "").toLowerCase().includes(term)
-    );
-  }, [lotes, search]);
+    return lotes.filter((l) => {
+      const isActive = activeLote?.id === l.id;
+      if (statusFilter === "activo" && !isActive) return false;
+      if (statusFilter === "inactivo" && isActive) return false;
+      if (productoFilter && l.productoNombre !== productoFilter) return false;
+      if (variedadFilter && l.variedadId !== variedadFilter) return false;
+      if (!term) return true;
+      return [
+        l.codigoLote,
+        l.productoNombre,
+        l.variedadNombre,
+        l.variedadTipo,
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(term);
+    });
+  }, [activeLote?.id, lotes, productoFilter, search, statusFilter, variedadFilter]);
 
   const variedadesForSelected = useMemo(() => {
     if (!selectedProductoId) return [];
@@ -112,6 +156,19 @@ export default function LotesPage() {
   const handleProductoChange = (productoId: string) => {
     setSelectedProductoId(productoId);
     setSelectedVariedadId("");
+  };
+
+  const hasListFilters =
+    search ||
+    productoFilter ||
+    variedadFilter ||
+    statusFilter !== "todos";
+
+  const clearListFilters = () => {
+    setSearch("");
+    setProductoFilter("");
+    setVariedadFilter("");
+    setStatusFilter("todos");
   };
 
   const handleCreateLote = async () => {
@@ -237,12 +294,101 @@ export default function LotesPage() {
           <CardTitle className="text-base text-white">Lotes del servicio</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Input
-            placeholder="Buscar lote…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="max-w-sm bg-slate-800/60 border-white/10 text-white placeholder:text-slate-500 focus-visible:ring-cyan-500"
-          />
+          <div className="space-y-3 rounded-lg border border-white/10 bg-slate-950/20 p-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                <Input
+                  placeholder="Buscar codigo, producto o variedad..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="h-10 bg-slate-800/60 pl-10 border-white/10 text-white placeholder:text-slate-500 focus-visible:ring-cyan-500"
+                />
+              </div>
+
+              <div className="flex gap-2 overflow-x-auto pb-1 lg:pb-0">
+                {[
+                  { key: "todos", label: "Todos", count: lotes.length },
+                  { key: "activo", label: "Activo", count: activeLote ? 1 : 0 },
+                  {
+                    key: "inactivo",
+                    label: "Inactivos",
+                    count: Math.max(0, lotes.length - (activeLote ? 1 : 0)),
+                  },
+                ].map((item) => {
+                  const active = statusFilter === item.key;
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => setStatusFilter(item.key as StatusFilter)}
+                      className={`shrink-0 rounded-md border px-3 py-2 text-xs font-medium transition-colors ${
+                        active
+                          ? "border-cyan-400/40 bg-cyan-500/10 text-cyan-200"
+                          : "border-white/10 bg-slate-900/40 text-slate-400 hover:border-white/20 hover:text-white"
+                      }`}
+                    >
+                      {item.label}
+                      <span className="ml-2 text-slate-500">{item.count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="grid gap-2 md:grid-cols-[1fr_1fr_auto]">
+              <Select
+                value={productoFilter || "all"}
+                onValueChange={(value) => {
+                  setProductoFilter(value === "all" ? "" : value);
+                  setVariedadFilter("");
+                }}
+              >
+                <SelectTrigger className="border-white/10 bg-slate-800/60 text-white focus:ring-cyan-500">
+                  <SelectValue placeholder="Producto" />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-800 border-white/10 text-white">
+                  <SelectItem value="all">Todos los productos</SelectItem>
+                  {productoOptions.map((producto) => (
+                    <SelectItem key={producto} value={producto}>
+                      {producto}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={variedadFilter || "all"}
+                onValueChange={(value) =>
+                  setVariedadFilter(value === "all" ? "" : value)
+                }
+              >
+                <SelectTrigger className="border-white/10 bg-slate-800/60 text-white focus:ring-cyan-500">
+                  <SelectValue placeholder="Variedad" />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-800 border-white/10 text-white">
+                  <SelectItem value="all">Todas las variedades</SelectItem>
+                  {variedadOptions.map((variedad) => (
+                    <SelectItem key={variedad.id} value={variedad.id}>
+                      {variedad.tipo ? `${variedad.tipo} · ` : ""}
+                      {variedad.nombre}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {hasListFilters && (
+                <Button
+                  variant="ghost"
+                  onClick={clearListFilters}
+                  className="text-slate-400 hover:bg-white/5 hover:text-white"
+                >
+                  <X className="h-4 w-4" />
+                  Limpiar
+                </Button>
+              )}
+            </div>
+          </div>
 
           <ScrollArea className="h-[420px] pr-2">
             {loading ? (


### PR DESCRIPTION
## Summary
- Adds advanced server-backed filters, sorting, facets, summaries, and export support for the global lotes table.
- Rebuilds the `/app/lotes` UI with a cleaner operational layout, filter chips, quick filters, sticky sortable table headers, and CSV/XLSX export.
- Adds compact filtering to the service-scoped lotes view for consistency.

## Validation
- `npm run build`
- Local Next route check: `HEAD /app/lotes` returned `200 OK`.