### PR TITLE
Chunk conteo bulk insert to stay under Postgres parameter limit

### DIFF
--- a/my-project/src/app/api/mediciones/sync/route.ts
+++ b/my-project/src/app/api/mediciones/sync/route.ts
@@ -344,22 +344,31 @@ export async function POST(request: Request) {
     }
   }
 
-  // 5. Bulk INSERT — un solo statement para N filas.
-  //    El trigger STATEMENT-level (migración 0009) dispara UNA vez
-  //    y agrega todo el batch a lote_stats; caja_stats solo si hay caja activa.
-  await db.insert(conteo).values(
-    rowsWithContext.map(({ medicion, session, assignment }) => ({
-      ts: medicion.ts,
-      loteId: session!.loteId,
-      servicioId: assignment!.servicioId,
-      dispositivoId: device.id,
-      cajaLoteSessionId: assignment!.usaCajas
-        ? cajaByLoteSessionId.get(session!.id) ?? null
-        : null,
-      perimeter: medicion.perimeter,
-      direction: medicion.direction,
-    }))
-  );
+  // 5. Bulk INSERT — chunked para no superar el límite de 65 535 parámetros
+  //    de PostgreSQL (7 columnas × 10 000 filas excedería el límite).
+  //    El trigger STATEMENT-level (migración 0009) es aditivo, así que
+  //    dispararlo una vez por chunk produce los mismos totales que una sola
+  //    sentencia. La transacción mantiene la semántica all-or-nothing.
+  const rows = rowsWithContext.map(({ medicion, session, assignment }) => ({
+    ts: medicion.ts,
+    loteId: session!.loteId,
+    servicioId: assignment!.servicioId,
+    dispositivoId: device.id,
+    cajaLoteSessionId: assignment!.usaCajas
+      ? cajaByLoteSessionId.get(session!.id) ?? null
+      : null,
+    perimeter: medicion.perimeter,
+    direction: medicion.direction,
+  }));
+
+  const CONTEO_INSERT_CHUNK_SIZE = 5000;
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < rows.length; i += CONTEO_INSERT_CHUNK_SIZE) {
+      await tx
+        .insert(conteo)
+        .values(rows.slice(i, i + CONTEO_INSERT_CHUNK_SIZE));
+    }
+  });
 
   return NextResponse.json({ accepted: mediciones.length }, { status: 200 });
 }


### PR DESCRIPTION
## Summary

- A full 10 000-medicion `/api/mediciones/sync` request built a single `INSERT INTO conteo` with `7 cols × 10 000 rows = 70 000` bind parameters, exceeding Postgres' hard limit of 65 535 and aborting the entire sync (`Failed query: insert into "conteo" ... ($1, ..., $30000+, ...)`).
- Split the insert into 5 000-row chunks inside a single `db.transaction` so atomicity is preserved and the request still succeeds for any batch up to `MAX_BATCH_SIZE`.

## Why this is safe

- 5 000 × 7 = 35 000 params per chunk — well under the 65 535 limit, with headroom if another column is ever added.
- The STATEMENT-level trigger added in `0009_device_ingestion_foundation.sql` (and the dual-path stats in `0013_stats_caja_dual_path.sql`) is additive — it sums deltas onto `lote_stats` / `caja_stats`. Firing it once per chunk produces identical totals to firing it once for the whole batch.
- Wrapping the chunked loop in `db.transaction(...)` keeps the prior all-or-nothing semantics: if any chunk fails, every chunk in the request rolls back.

## Notes for reviewer

- Only `my-project/src/app/api/mediciones/sync/route.ts` changes — no schema, API contract, or client changes.
- `MAX_BATCH_SIZE = 10_000` is unchanged; clients don't need updates.
- `npx tsc --noEmit` passes locally. End-to-end verification against a real device + lote session was not run (requires seeding test rows in the DB); recommended manual checks:
  1. POST 10 000 mediciones → expect `200 { accepted: 10000 }`.
  2. `SUM(conteo_in + conteo_out)` on `lote_stats` / `caja_stats` for the affected lote increases by exactly 10 000.
  3. Force a mid-chunk failure (e.g. a constraint violation in chunk 2) and confirm zero `conteo` rows from chunk 1 remain.
  4. Re-run with 100 and 4 999 mediciones to confirm no regression on the common case.

## Test plan

- [ ] Deploy to staging / preview
- [ ] POST 10 000 mediciones, confirm `200 { accepted: 10000 }`
- [ ] Diff `lote_stats` / `caja_stats` before/after; deltas match counts
- [ ] Force a mid-chunk failure; confirm full rollback
- [ ] Re-run with 100 and 4 999 mediciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)