### PR TITLE
Lower conteo chunk size to fit postgres-js Int16 bind limit

### DIFF
--- a/my-project/src/app/api/mediciones/sync/route.ts
+++ b/my-project/src/app/api/mediciones/sync/route.ts
@@ -344,8 +344,9 @@ export async function POST(request: Request) {
     }
   }
 
-  // 5. Bulk INSERT — chunked para no superar el límite de 65 535 parámetros
-  //    de PostgreSQL (7 columnas × 10 000 filas excedería el límite).
+  // 5. Bulk INSERT — chunked para no superar el límite de 32 767 parámetros
+  //    del driver postgres-js (la cuenta de parámetros se serializa como Int16
+  //    en el mensaje Bind del protocolo de Postgres, no los 65 535 del server).
   //    El trigger STATEMENT-level (migración 0009) es aditivo, así que
   //    dispararlo una vez por chunk produce los mismos totales que una sola
   //    sentencia. La transacción mantiene la semántica all-or-nothing.
@@ -361,7 +362,8 @@ export async function POST(request: Request) {
     direction: medicion.direction,
   }));
 
-  const CONTEO_INSERT_CHUNK_SIZE = 5000;
+  // 7 columnas × 4000 = 28 000 parámetros (margen bajo el límite de 32 767).
+  const CONTEO_INSERT_CHUNK_SIZE = 4000;
   await db.transaction(async (tx) => {
     for (let i = 0; i < rows.length; i += CONTEO_INSERT_CHUNK_SIZE) {
       await tx


### PR DESCRIPTION
## Summary

Follow-up to [#69](https://github.com/Dxeg0o/STASS/pull/69). The chunked insert still fails on large batches because postgres-js has a stricter parameter limit than Postgres itself:

- Postgres server limit: **65 535** bind parameters per statement.
- postgres-js wire-protocol limit: **32 767** — the parameter count is encoded as Int16 in the Bind message, so the practical cap is half the server's.

PR #69 chose chunks of 5000 rows × 7 cols = **35 000 params**, which exceeds the driver's 32 767 limit. The error log after merge shows the same `Failed query: insert into "conteo" ...` truncated past `$32 960`, confirming the driver hits Int16 overflow mid-serialization.

Dropping chunk size to **4000 rows** (28 000 params) leaves a safe margin while still keeping the round-trip count reasonable (max 3 chunks for the largest 10 000-row batch).

## Files changed

- `my-project/src/app/api/mediciones/sync/route.ts` — `CONTEO_INSERT_CHUNK_SIZE: 5000 → 4000`, comment updated to reflect the real limit.

## Test plan

- [ ] Deploy to production / preview
- [ ] POST 10 000 mediciones — expect `200 { accepted: 10000 }` (3 chunks of 4000 / 4000 / 2000)
- [ ] Confirm `lote_stats` / `caja_stats` deltas match the inserted counts
- [ ] Smaller batches (100, 4000) still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)