### PR TITLE
feat: add lote_total_stats and caja_total_stats for perimeter-agnostic counts

### DIFF
--- a/my-project/drizzle/0018_windy_kang.sql
+++ b/my-project/drizzle/0018_windy_kang.sql
@@ -1,0 +1,183 @@
+CREATE TABLE "caja_total_stats" (
+	"caja_lote_session_id" uuid NOT NULL,
+	"dispositivo_id" uuid NOT NULL,
+	"count_in" integer DEFAULT 0 NOT NULL,
+	"count_out" integer DEFAULT 0 NOT NULL,
+	"first_ts" timestamp with time zone,
+	"last_ts" timestamp with time zone,
+	CONSTRAINT "caja_total_stats_caja_lote_session_id_dispositivo_id_pk" PRIMARY KEY("caja_lote_session_id","dispositivo_id")
+);
+--> statement-breakpoint
+CREATE TABLE "lote_total_stats" (
+	"lote_id" uuid NOT NULL,
+	"servicio_id" uuid NOT NULL,
+	"dispositivo_id" uuid NOT NULL,
+	"count_in" integer DEFAULT 0 NOT NULL,
+	"count_out" integer DEFAULT 0 NOT NULL,
+	"first_ts" timestamp with time zone,
+	"last_ts" timestamp with time zone,
+	CONSTRAINT "lote_total_stats_lote_id_servicio_id_dispositivo_id_pk" PRIMARY KEY("lote_id","servicio_id","dispositivo_id")
+);
+--> statement-breakpoint
+ALTER TABLE "caja_total_stats" ADD CONSTRAINT "caja_total_stats_caja_lote_session_id_caja_lote_session_id_fk" FOREIGN KEY ("caja_lote_session_id") REFERENCES "public"."caja_lote_session"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "caja_total_stats" ADD CONSTRAINT "caja_total_stats_dispositivo_id_dispositivo_id_fk" FOREIGN KEY ("dispositivo_id") REFERENCES "public"."dispositivo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lote_total_stats" ADD CONSTRAINT "lote_total_stats_lote_id_lote_id_fk" FOREIGN KEY ("lote_id") REFERENCES "public"."lote"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lote_total_stats" ADD CONSTRAINT "lote_total_stats_servicio_id_servicio_id_fk" FOREIGN KEY ("servicio_id") REFERENCES "public"."servicio"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "lote_total_stats" ADD CONSTRAINT "lote_total_stats_dispositivo_id_dispositivo_id_fk" FOREIGN KEY ("dispositivo_id") REFERENCES "public"."dispositivo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+
+ALTER TABLE "conteo" ALTER COLUMN "perimeter" DROP NOT NULL;
+--> statement-breakpoint
+
+INSERT INTO lote_total_stats (
+  lote_id, servicio_id, dispositivo_id,
+  count_in, count_out, first_ts, last_ts
+)
+SELECT
+  c.lote_id,
+  c.servicio_id,
+  c.dispositivo_id,
+  SUM(CASE WHEN c.direction = 0 THEN 1 ELSE 0 END)::int,
+  SUM(CASE WHEN c.direction = 1 THEN 1 ELSE 0 END)::int,
+  MIN(c.ts),
+  MAX(c.ts)
+FROM conteo c
+GROUP BY c.lote_id, c.servicio_id, c.dispositivo_id
+ON CONFLICT (lote_id, servicio_id, dispositivo_id) DO UPDATE SET
+  count_in  = lote_total_stats.count_in  + excluded.count_in,
+  count_out = lote_total_stats.count_out + excluded.count_out,
+  first_ts  = LEAST(lote_total_stats.first_ts, excluded.first_ts),
+  last_ts   = GREATEST(lote_total_stats.last_ts, excluded.last_ts);
+--> statement-breakpoint
+
+INSERT INTO caja_total_stats (
+  caja_lote_session_id, dispositivo_id,
+  count_in, count_out, first_ts, last_ts
+)
+SELECT
+  c.caja_lote_session_id,
+  c.dispositivo_id,
+  SUM(CASE WHEN c.direction = 0 THEN 1 ELSE 0 END)::int,
+  SUM(CASE WHEN c.direction = 1 THEN 1 ELSE 0 END)::int,
+  MIN(c.ts),
+  MAX(c.ts)
+FROM conteo c
+WHERE c.caja_lote_session_id IS NOT NULL
+GROUP BY c.caja_lote_session_id, c.dispositivo_id
+ON CONFLICT (caja_lote_session_id, dispositivo_id) DO UPDATE SET
+  count_in  = caja_total_stats.count_in  + excluded.count_in,
+  count_out = caja_total_stats.count_out + excluded.count_out,
+  first_ts  = LEAST(caja_total_stats.first_ts, excluded.first_ts),
+  last_ts   = GREATEST(caja_total_stats.last_ts, excluded.last_ts);
+--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION update_lote_stats()
+RETURNS trigger AS $$
+BEGIN
+  -- Totales por lote: incluyen mediciones con y sin calibre.
+  INSERT INTO lote_total_stats (
+    lote_id, servicio_id, dispositivo_id,
+    count_in, count_out, first_ts, last_ts
+  )
+  SELECT
+    r.lote_id,
+    r.servicio_id,
+    r.dispositivo_id,
+    SUM(CASE WHEN r.direction = 0 THEN 1 ELSE 0 END)::int,
+    SUM(CASE WHEN r.direction = 1 THEN 1 ELSE 0 END)::int,
+    MIN(r.ts),
+    MAX(r.ts)
+  FROM new_rows r
+  GROUP BY r.lote_id, r.servicio_id, r.dispositivo_id
+  ON CONFLICT (lote_id, servicio_id, dispositivo_id) DO UPDATE SET
+    count_in  = lote_total_stats.count_in  + excluded.count_in,
+    count_out = lote_total_stats.count_out + excluded.count_out,
+    first_ts  = LEAST(lote_total_stats.first_ts, excluded.first_ts),
+    last_ts   = GREATEST(lote_total_stats.last_ts, excluded.last_ts);
+
+  -- Distribucion por calibre: solo mediciones con calibre real.
+  INSERT INTO lote_stats (
+    lote_id, servicio_id, dispositivo_id, calibre,
+    count_in, count_out, first_ts, last_ts
+  )
+  SELECT
+    r.lote_id,
+    r.servicio_id,
+    r.dispositivo_id,
+    ROUND(r.perimeter::numeric, 1)::real,
+    SUM(CASE WHEN r.direction = 0 THEN 1 ELSE 0 END)::int,
+    SUM(CASE WHEN r.direction = 1 THEN 1 ELSE 0 END)::int,
+    MIN(r.ts),
+    MAX(r.ts)
+  FROM new_rows r
+  WHERE r.perimeter IS NOT NULL
+  GROUP BY
+    r.lote_id,
+    r.servicio_id,
+    r.dispositivo_id,
+    ROUND(r.perimeter::numeric, 1)::real
+  ON CONFLICT (lote_id, servicio_id, dispositivo_id, calibre) DO UPDATE SET
+    count_in  = lote_stats.count_in  + excluded.count_in,
+    count_out = lote_stats.count_out + excluded.count_out,
+    first_ts  = LEAST(lote_stats.first_ts, excluded.first_ts),
+    last_ts   = GREATEST(lote_stats.last_ts, excluded.last_ts);
+
+  -- Totales por caja: incluyen mediciones con y sin calibre.
+  INSERT INTO caja_total_stats (
+    caja_lote_session_id, dispositivo_id,
+    count_in, count_out, first_ts, last_ts
+  )
+  SELECT
+    r.caja_lote_session_id,
+    r.dispositivo_id,
+    SUM(CASE WHEN r.direction = 0 THEN 1 ELSE 0 END)::int,
+    SUM(CASE WHEN r.direction = 1 THEN 1 ELSE 0 END)::int,
+    MIN(r.ts),
+    MAX(r.ts)
+  FROM new_rows r
+  WHERE r.caja_lote_session_id IS NOT NULL
+  GROUP BY r.caja_lote_session_id, r.dispositivo_id
+  ON CONFLICT (caja_lote_session_id, dispositivo_id) DO UPDATE SET
+    count_in  = caja_total_stats.count_in  + excluded.count_in,
+    count_out = caja_total_stats.count_out + excluded.count_out,
+    first_ts  = LEAST(caja_total_stats.first_ts, excluded.first_ts),
+    last_ts   = GREATEST(caja_total_stats.last_ts, excluded.last_ts);
+
+  -- Distribucion por caja/calibre: solo mediciones con calibre real.
+  INSERT INTO caja_stats (
+    caja_lote_session_id, dispositivo_id, calibre,
+    count_in, count_out, first_ts, last_ts
+  )
+  SELECT
+    r.caja_lote_session_id,
+    r.dispositivo_id,
+    ROUND(r.perimeter::numeric, 1)::real,
+    SUM(CASE WHEN r.direction = 0 THEN 1 ELSE 0 END)::int,
+    SUM(CASE WHEN r.direction = 1 THEN 1 ELSE 0 END)::int,
+    MIN(r.ts),
+    MAX(r.ts)
+  FROM new_rows r
+  WHERE r.caja_lote_session_id IS NOT NULL
+    AND r.perimeter IS NOT NULL
+  GROUP BY
+    r.caja_lote_session_id,
+    r.dispositivo_id,
+    ROUND(r.perimeter::numeric, 1)::real
+  ON CONFLICT (caja_lote_session_id, dispositivo_id, calibre) DO UPDATE SET
+    count_in  = caja_stats.count_in  + excluded.count_in,
+    count_out = caja_stats.count_out + excluded.count_out,
+    first_ts  = LEAST(caja_stats.first_ts, excluded.first_ts),
+    last_ts   = GREATEST(caja_stats.last_ts, excluded.last_ts);
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+DROP TRIGGER IF EXISTS conteo_stats_trigger ON "conteo";
+--> statement-breakpoint
+
+CREATE TRIGGER conteo_stats_trigger
+  AFTER INSERT ON "conteo"
+  REFERENCING NEW TABLE AS new_rows
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION update_lote_stats();

--- a/my-project/drizzle/meta/0018_snapshot.json
+++ b/my-project/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2118 @@
+{
+  "id": "d2e66b64-3f37-46b6-9c3e-62a9609295b2",
+  "prevId": "69714f63-32ab-4f82-ba3c-952e1331a5a1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.caja": {
+      "name": "caja",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reutilizable'"
+        },
+        "capacidad": {
+          "name": "capacidad",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caja_empresa_id_empresa_id_fk": {
+          "name": "caja_empresa_id_empresa_id_fk",
+          "tableFrom": "caja",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "caja_codigo_unique": {
+          "name": "caja_codigo_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codigo"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caja_lote_session": {
+      "name": "caja_lote_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "caja_id": {
+          "name": "caja_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lote_session_id": {
+          "name": "lote_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asignado_at": {
+          "name": "asignado_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "retirado_at": {
+          "name": "retirado_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caja_lote_session_caja_id_caja_id_fk": {
+          "name": "caja_lote_session_caja_id_caja_id_fk",
+          "tableFrom": "caja_lote_session",
+          "tableTo": "caja",
+          "columnsFrom": [
+            "caja_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "caja_lote_session_lote_session_id_lote_session_id_fk": {
+          "name": "caja_lote_session_lote_session_id_lote_session_id_fk",
+          "tableFrom": "caja_lote_session",
+          "tableTo": "lote_session",
+          "columnsFrom": [
+            "lote_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caja_stats": {
+      "name": "caja_stats",
+      "schema": "",
+      "columns": {
+        "caja_lote_session_id": {
+          "name": "caja_lote_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calibre": {
+          "name": "calibre",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_in": {
+          "name": "count_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_out": {
+          "name": "count_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_ts": {
+          "name": "first_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ts": {
+          "name": "last_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caja_stats_caja_lote_session_id_caja_lote_session_id_fk": {
+          "name": "caja_stats_caja_lote_session_id_caja_lote_session_id_fk",
+          "tableFrom": "caja_stats",
+          "tableTo": "caja_lote_session",
+          "columnsFrom": [
+            "caja_lote_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caja_stats_dispositivo_id_dispositivo_id_fk": {
+          "name": "caja_stats_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "caja_stats",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caja_stats_caja_lote_session_id_dispositivo_id_calibre_pk": {
+          "name": "caja_stats_caja_lote_session_id_dispositivo_id_calibre_pk",
+          "columns": [
+            "caja_lote_session_id",
+            "dispositivo_id",
+            "calibre"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.caja_total_stats": {
+      "name": "caja_total_stats",
+      "schema": "",
+      "columns": {
+        "caja_lote_session_id": {
+          "name": "caja_lote_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_in": {
+          "name": "count_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_out": {
+          "name": "count_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_ts": {
+          "name": "first_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ts": {
+          "name": "last_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "caja_total_stats_caja_lote_session_id_caja_lote_session_id_fk": {
+          "name": "caja_total_stats_caja_lote_session_id_caja_lote_session_id_fk",
+          "tableFrom": "caja_total_stats",
+          "tableTo": "caja_lote_session",
+          "columnsFrom": [
+            "caja_lote_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "caja_total_stats_dispositivo_id_dispositivo_id_fk": {
+          "name": "caja_total_stats_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "caja_total_stats",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "caja_total_stats_caja_lote_session_id_dispositivo_id_pk": {
+          "name": "caja_total_stats_caja_lote_session_id_dispositivo_id_pk",
+          "columns": [
+            "caja_lote_session_id",
+            "dispositivo_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conteo": {
+      "name": "conteo",
+      "schema": "",
+      "columns": {
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicio_id": {
+          "name": "servicio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lote_id": {
+          "name": "lote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caja_lote_session_id": {
+          "name": "caja_lote_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "perimeter": {
+          "name": "perimeter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_conteo_lote": {
+          "name": "idx_conteo_lote",
+          "columns": [
+            {
+              "expression": "lote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conteo_servicio": {
+          "name": "idx_conteo_servicio",
+          "columns": [
+            {
+              "expression": "servicio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_conteo_dispositivo": {
+          "name": "idx_conteo_dispositivo",
+          "columns": [
+            {
+              "expression": "dispositivo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conteo_servicio_id_servicio_id_fk": {
+          "name": "conteo_servicio_id_servicio_id_fk",
+          "tableFrom": "conteo",
+          "tableTo": "servicio",
+          "columnsFrom": [
+            "servicio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conteo_lote_id_lote_id_fk": {
+          "name": "conteo_lote_id_lote_id_fk",
+          "tableFrom": "conteo",
+          "tableTo": "lote",
+          "columnsFrom": [
+            "lote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conteo_dispositivo_id_dispositivo_id_fk": {
+          "name": "conteo_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "conteo",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conteo_caja_lote_session_id_caja_lote_session_id_fk": {
+          "name": "conteo_caja_lote_session_id_caja_lote_session_id_fk",
+          "tableFrom": "conteo",
+          "tableTo": "caja_lote_session",
+          "columnsFrom": [
+            "caja_lote_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conteo_archive_index": {
+      "name": "conteo_archive_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conteo_archive_index_date_unique": {
+          "name": "conteo_archive_index_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispositivo": {
+      "name": "dispositivo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nvidia_agx'"
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dispositivo_nombre_unique": {
+          "name": "dispositivo_nombre_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nombre"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispositivo_servicio": {
+      "name": "dispositivo_servicio",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicio_id": {
+          "name": "servicio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maquina": {
+          "name": "maquina",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asignado_at": {
+          "name": "asignado_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "fecha_inicio": {
+          "name": "fecha_inicio",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_termino": {
+          "name": "fecha_termino",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dispositivo_servicio_dispositivo_id_dispositivo_id_fk": {
+          "name": "dispositivo_servicio_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "dispositivo_servicio",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dispositivo_servicio_servicio_id_servicio_id_fk": {
+          "name": "dispositivo_servicio_servicio_id_servicio_id_fk",
+          "tableFrom": "dispositivo_servicio",
+          "tableTo": "servicio",
+          "columnsFrom": [
+            "servicio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.empresa": {
+      "name": "empresa",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pais": {
+          "name": "pais",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.empresa_usuario": {
+      "name": "empresa_usuario",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "usuario_id": {
+          "name": "usuario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rol": {
+          "name": "rol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "empresa_usuario_usuario_id_usuario_id_fk": {
+          "name": "empresa_usuario_usuario_id_usuario_id_fk",
+          "tableFrom": "empresa_usuario",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "empresa_usuario_empresa_id_empresa_id_fk": {
+          "name": "empresa_usuario_empresa_id_empresa_id_fk",
+          "tableFrom": "empresa_usuario",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "empresa_usuario_usuario_id_empresa_id_unique": {
+          "name": "empresa_usuario_usuario_id_empresa_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "usuario_id",
+            "empresa_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_link": {
+      "name": "invitation_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rol": {
+          "name": "rol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correo_invitado": {
+          "name": "correo_invitado",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by_usuario_id": {
+          "name": "used_by_usuario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_link_empresa_id_empresa_id_fk": {
+          "name": "invitation_link_empresa_id_empresa_id_fk",
+          "tableFrom": "invitation_link",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_link_used_by_usuario_id_usuario_id_fk": {
+          "name": "invitation_link_used_by_usuario_id_usuario_id_fk",
+          "tableFrom": "invitation_link",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "used_by_usuario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitation_link_created_by_usuario_id_fk": {
+          "name": "invitation_link_created_by_usuario_id_fk",
+          "tableFrom": "invitation_link",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitation_link_token_unique": {
+          "name": "invitation_link_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lote": {
+      "name": "lote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "codigo_lote": {
+          "name": "codigo_lote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variedad_id": {
+          "name": "variedad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subvariedad_id": {
+          "name": "subvariedad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lote_variedad_id_variedad_id_fk": {
+          "name": "lote_variedad_id_variedad_id_fk",
+          "tableFrom": "lote",
+          "tableTo": "variedad",
+          "columnsFrom": [
+            "variedad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lote_subvariedad_id_subvariedad_id_fk": {
+          "name": "lote_subvariedad_id_subvariedad_id_fk",
+          "tableFrom": "lote",
+          "tableTo": "subvariedad",
+          "columnsFrom": [
+            "subvariedad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lote_servicio": {
+      "name": "lote_servicio",
+      "schema": "",
+      "columns": {
+        "lote_id": {
+          "name": "lote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicio_id": {
+          "name": "servicio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asignado_at": {
+          "name": "asignado_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lote_servicio_lote_id_lote_id_fk": {
+          "name": "lote_servicio_lote_id_lote_id_fk",
+          "tableFrom": "lote_servicio",
+          "tableTo": "lote",
+          "columnsFrom": [
+            "lote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lote_servicio_servicio_id_servicio_id_fk": {
+          "name": "lote_servicio_servicio_id_servicio_id_fk",
+          "tableFrom": "lote_servicio",
+          "tableTo": "servicio",
+          "columnsFrom": [
+            "servicio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lote_servicio_lote_id_servicio_id_pk": {
+          "name": "lote_servicio_lote_id_servicio_id_pk",
+          "columns": [
+            "lote_id",
+            "servicio_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lote_session": {
+      "name": "lote_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lote_id": {
+          "name": "lote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lote_session_lote_id_lote_id_fk": {
+          "name": "lote_session_lote_id_lote_id_fk",
+          "tableFrom": "lote_session",
+          "tableTo": "lote",
+          "columnsFrom": [
+            "lote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lote_session_dispositivo_id_dispositivo_id_fk": {
+          "name": "lote_session_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "lote_session",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lote_stats": {
+      "name": "lote_stats",
+      "schema": "",
+      "columns": {
+        "lote_id": {
+          "name": "lote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicio_id": {
+          "name": "servicio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calibre": {
+          "name": "calibre",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_in": {
+          "name": "count_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_out": {
+          "name": "count_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_ts": {
+          "name": "first_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ts": {
+          "name": "last_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lote_stats_lote_id_lote_id_fk": {
+          "name": "lote_stats_lote_id_lote_id_fk",
+          "tableFrom": "lote_stats",
+          "tableTo": "lote",
+          "columnsFrom": [
+            "lote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lote_stats_servicio_id_servicio_id_fk": {
+          "name": "lote_stats_servicio_id_servicio_id_fk",
+          "tableFrom": "lote_stats",
+          "tableTo": "servicio",
+          "columnsFrom": [
+            "servicio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lote_stats_dispositivo_id_dispositivo_id_fk": {
+          "name": "lote_stats_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "lote_stats",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lote_stats_lote_id_servicio_id_dispositivo_id_calibre_pk": {
+          "name": "lote_stats_lote_id_servicio_id_dispositivo_id_calibre_pk",
+          "columns": [
+            "lote_id",
+            "servicio_id",
+            "dispositivo_id",
+            "calibre"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lote_total_stats": {
+      "name": "lote_total_stats",
+      "schema": "",
+      "columns": {
+        "lote_id": {
+          "name": "lote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servicio_id": {
+          "name": "servicio_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispositivo_id": {
+          "name": "dispositivo_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count_in": {
+          "name": "count_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "count_out": {
+          "name": "count_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "first_ts": {
+          "name": "first_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ts": {
+          "name": "last_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lote_total_stats_lote_id_lote_id_fk": {
+          "name": "lote_total_stats_lote_id_lote_id_fk",
+          "tableFrom": "lote_total_stats",
+          "tableTo": "lote",
+          "columnsFrom": [
+            "lote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lote_total_stats_servicio_id_servicio_id_fk": {
+          "name": "lote_total_stats_servicio_id_servicio_id_fk",
+          "tableFrom": "lote_total_stats",
+          "tableTo": "servicio",
+          "columnsFrom": [
+            "servicio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lote_total_stats_dispositivo_id_dispositivo_id_fk": {
+          "name": "lote_total_stats_dispositivo_id_dispositivo_id_fk",
+          "tableFrom": "lote_total_stats",
+          "tableTo": "dispositivo",
+          "columnsFrom": [
+            "dispositivo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lote_total_stats_lote_id_servicio_id_dispositivo_id_pk": {
+          "name": "lote_total_stats_lote_id_servicio_id_dispositivo_id_pk",
+          "columns": [
+            "lote_id",
+            "servicio_id",
+            "dispositivo_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.proceso": {
+      "name": "proceso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tipo_proceso_id": {
+          "name": "tipo_proceso_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producto_id": {
+          "name": "producto_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporada": {
+          "name": "temporada",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estado": {
+          "name": "estado",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planificado'"
+        },
+        "fecha_inicio": {
+          "name": "fecha_inicio",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_fin": {
+          "name": "fecha_fin",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "proceso_tipo_proceso_id_tipo_proceso_id_fk": {
+          "name": "proceso_tipo_proceso_id_tipo_proceso_id_fk",
+          "tableFrom": "proceso",
+          "tableTo": "tipo_proceso",
+          "columnsFrom": [
+            "tipo_proceso_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "proceso_empresa_id_empresa_id_fk": {
+          "name": "proceso_empresa_id_empresa_id_fk",
+          "tableFrom": "proceso",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "proceso_producto_id_producto_id_fk": {
+          "name": "proceso_producto_id_producto_id_fk",
+          "tableFrom": "proceso",
+          "tableTo": "producto",
+          "columnsFrom": [
+            "producto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.producto": {
+      "name": "producto",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "producto_nombre_unique": {
+          "name": "producto_nombre_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nombre"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servicio": {
+      "name": "servicio",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ubicacion_id": {
+          "name": "ubicacion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proceso_id": {
+          "name": "proceso_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usa_cajas": {
+          "name": "usa_cajas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estado": {
+          "name": "estado",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planificado'"
+        },
+        "fecha_inicio": {
+          "name": "fecha_inicio",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha_fin": {
+          "name": "fecha_fin",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "servicio_empresa_id_empresa_id_fk": {
+          "name": "servicio_empresa_id_empresa_id_fk",
+          "tableFrom": "servicio",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "servicio_ubicacion_id_ubicacion_id_fk": {
+          "name": "servicio_ubicacion_id_ubicacion_id_fk",
+          "tableFrom": "servicio",
+          "tableTo": "ubicacion",
+          "columnsFrom": [
+            "ubicacion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "servicio_proceso_id_proceso_id_fk": {
+          "name": "servicio_proceso_id_proceso_id_fk",
+          "tableFrom": "servicio",
+          "tableTo": "proceso",
+          "columnsFrom": [
+            "proceso_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subvariedad": {
+      "name": "subvariedad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variedad_id": {
+          "name": "variedad_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subvariedad_variedad_id_variedad_id_fk": {
+          "name": "subvariedad_variedad_id_variedad_id_fk",
+          "tableFrom": "subvariedad",
+          "tableTo": "variedad",
+          "columnsFrom": [
+            "variedad_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subvariedad_nombre_variedad_id_unique": {
+          "name": "subvariedad_nombre_variedad_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nombre",
+            "variedad_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tipo_proceso": {
+      "name": "tipo_proceso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tipo_proceso_empresa_id_empresa_id_fk": {
+          "name": "tipo_proceso_empresa_id_empresa_id_fk",
+          "tableFrom": "tipo_proceso",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ubicacion": {
+      "name": "ubicacion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundaries": {
+          "name": "boundaries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ubicacion_empresa_id_empresa_id_fk": {
+          "name": "ubicacion_empresa_id_empresa_id_fk",
+          "tableFrom": "ubicacion",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usuario": {
+      "name": "usuario",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correo": {
+          "name": "correo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expires_at": {
+          "name": "reset_password_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "usuario_correo_unique": {
+          "name": "usuario_correo_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "correo"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variedad": {
+      "name": "variedad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "producto_id": {
+          "name": "producto_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "variedad_producto_id_producto_id_fk": {
+          "name": "variedad_producto_id_producto_id_fk",
+          "tableFrom": "variedad",
+          "tableTo": "producto",
+          "columnsFrom": [
+            "producto_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "variedad_nombre_producto_id_unique": {
+          "name": "variedad_nombre_producto_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nombre",
+            "producto_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_empresa": {
+      "name": "workflow_empresa",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "empresa_id": {
+          "name": "empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_empresa_empresa_id_empresa_id_fk": {
+          "name": "workflow_empresa_empresa_id_empresa_id_fk",
+          "tableFrom": "workflow_empresa",
+          "tableTo": "empresa",
+          "columnsFrom": [
+            "empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_paso": {
+      "name": "workflow_paso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_empresa_id": {
+          "name": "workflow_empresa_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_proceso_id": {
+          "name": "tipo_proceso_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orden": {
+          "name": "orden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_paso_workflow_empresa_id_workflow_empresa_id_fk": {
+          "name": "workflow_paso_workflow_empresa_id_workflow_empresa_id_fk",
+          "tableFrom": "workflow_paso",
+          "tableTo": "workflow_empresa",
+          "columnsFrom": [
+            "workflow_empresa_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_paso_tipo_proceso_id_tipo_proceso_id_fk": {
+          "name": "workflow_paso_tipo_proceso_id_tipo_proceso_id_fk",
+          "tableFrom": "workflow_paso",
+          "tableTo": "tipo_proceso",
+          "columnsFrom": [
+            "tipo_proceso_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_paso_workflow_empresa_id_orden_unique": {
+          "name": "workflow_paso_workflow_empresa_id_orden_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_empresa_id",
+            "orden"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/my-project/drizzle/meta/_journal.json
+++ b/my-project/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1778021117131,
       "tag": "0017_strange_peter_quill",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1778618583691,
+      "tag": "0018_windy_kang",
+      "breakpoints": true
     }
   ]
 }

--- a/my-project/src/app/api/cajas/session/route.ts
+++ b/my-project/src/app/api/cajas/session/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/db";
-import { caja, cajaLoteSession, cajaStats, loteSession } from "@/db/schema";
+import { caja, cajaLoteSession, cajaTotalStats, loteSession } from "@/db/schema";
 
 async function resolveCajaId(input: {
   cajaId?: unknown;
@@ -58,12 +58,15 @@ export async function GET(request: Request) {
       loteSessionId: cajaLoteSession.loteSessionId,
       asignadoAt: cajaLoteSession.asignadoAt,
       retiradoAt: cajaLoteSession.retiradoAt,
-      totalCount: sql<number>`COALESCE(SUM(${cajaStats.countIn} + ${cajaStats.countOut}), 0)::int`,
-      lastTs: sql<Date | null>`MAX(${cajaStats.lastTs})`,
+      totalCount: sql<number>`COALESCE(SUM(${cajaTotalStats.countIn} + ${cajaTotalStats.countOut}), 0)::int`,
+      lastTs: sql<Date | null>`MAX(${cajaTotalStats.lastTs})`,
     })
     .from(cajaLoteSession)
     .innerJoin(caja, eq(caja.id, cajaLoteSession.cajaId))
-    .leftJoin(cajaStats, eq(cajaStats.cajaLoteSessionId, cajaLoteSession.id))
+    .leftJoin(
+      cajaTotalStats,
+      eq(cajaTotalStats.cajaLoteSessionId, cajaLoteSession.id)
+    )
     .where(and(...conditions))
     .groupBy(
       cajaLoteSession.id,

--- a/my-project/src/app/api/dashboard/overview/route.ts
+++ b/my-project/src/app/api/dashboard/overview/route.ts
@@ -6,7 +6,7 @@ import {
   servicio,
   lote,
   loteSession,
-  loteStats,
+  loteTotalStats,
   loteServicio,
   dispositivo,
   proceso,
@@ -54,16 +54,16 @@ export async function GET(request: Request) {
   }[] = [];
 
   if (servicioIds.length > 0) {
-    // Get stats aggregated by servicio via loteStats.servicioId
+    // Get total stats aggregated by servicio.
     const statsRows = await db
       .select({
-        servicioId: loteStats.servicioId,
-        totalBulbs: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+        servicioId: loteTotalStats.servicioId,
+        totalBulbs: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+        lastTs: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
       })
-      .from(loteStats)
-      .where(inArray(loteStats.servicioId, servicioIds))
-      .groupBy(loteStats.servicioId);
+      .from(loteTotalStats)
+      .where(inArray(loteTotalStats.servicioId, servicioIds))
+      .groupBy(loteTotalStats.servicioId);
 
     const statsMap = new Map(statsRows.map((r) => [r.servicioId, r]));
 
@@ -185,18 +185,18 @@ export async function GET(request: Request) {
         codigoLote: lote.codigoLote,
         servicioId: loteServicio.servicioId,
         servicioNombre: servicio.nombre,
-        totalCount: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+        totalCount: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+        lastTs: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
         createdAt: lote.createdAt,
       })
       .from(loteServicio)
       .innerJoin(lote, eq(lote.id, loteServicio.loteId))
       .innerJoin(servicio, eq(servicio.id, loteServicio.servicioId))
       .leftJoin(
-        loteStats,
+        loteTotalStats,
         and(
-          eq(loteStats.loteId, loteServicio.loteId),
-          eq(loteStats.servicioId, loteServicio.servicioId)
+          eq(loteTotalStats.loteId, loteServicio.loteId),
+          eq(loteTotalStats.servicioId, loteServicio.servicioId)
         )
       )
       .where(inArray(loteServicio.servicioId, servicioIds))

--- a/my-project/src/app/api/lotes/[loteId]/detail/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/detail/route.ts
@@ -4,7 +4,7 @@ import {
   lote,
   loteServicio,
   loteSession,
-  loteStats,
+  loteTotalStats,
   servicio,
   variedad,
   producto,
@@ -79,40 +79,40 @@ export async function GET(
   // 4. Aggregated stats per service
   const statsPerService = await db
     .select({
-      servicioId: loteStats.servicioId,
-      totalIn: sql<number>`SUM(${loteStats.countIn})::int`,
-      totalOut: sql<number>`SUM(${loteStats.countOut})::int`,
-      firstTs: sql<string | null>`MIN(${loteStats.firstTs})`,
-      lastTs: sql<string | null>`MAX(${loteStats.lastTs})`,
+      servicioId: loteTotalStats.servicioId,
+      totalIn: sql<number>`SUM(${loteTotalStats.countIn})::int`,
+      totalOut: sql<number>`SUM(${loteTotalStats.countOut})::int`,
+      firstTs: sql<string | null>`MIN(${loteTotalStats.firstTs})`,
+      lastTs: sql<string | null>`MAX(${loteTotalStats.lastTs})`,
     })
-    .from(loteStats)
-    .where(eq(loteStats.loteId, loteId))
-    .groupBy(loteStats.servicioId);
+    .from(loteTotalStats)
+    .where(eq(loteTotalStats.loteId, loteId))
+    .groupBy(loteTotalStats.servicioId);
 
   const statsMap = new Map(statsPerService.map((s) => [s.servicioId, s]));
 
   // 5. Total aggregated stats
   const totalStats = await db
     .select({
-      totalIn: sql<number>`COALESCE(SUM(${loteStats.countIn}), 0)::int`,
-      totalOut: sql<number>`COALESCE(SUM(${loteStats.countOut}), 0)::int`,
+      totalIn: sql<number>`COALESCE(SUM(${loteTotalStats.countIn}), 0)::int`,
+      totalOut: sql<number>`COALESCE(SUM(${loteTotalStats.countOut}), 0)::int`,
     })
-    .from(loteStats)
-    .where(eq(loteStats.loteId, loteId));
+    .from(loteTotalStats)
+    .where(eq(loteTotalStats.loteId, loteId));
 
   // 6. Device breakdown
   const deviceStats = await db
     .select({
-      dispositivoId: loteStats.dispositivoId,
+      dispositivoId: loteTotalStats.dispositivoId,
       dispositivoNombre: dispositivo.nombre,
-      totalIn: sql<number>`SUM(${loteStats.countIn})::int`,
-      totalOut: sql<number>`SUM(${loteStats.countOut})::int`,
-      lastTs: sql<string | null>`MAX(${loteStats.lastTs})`,
+      totalIn: sql<number>`SUM(${loteTotalStats.countIn})::int`,
+      totalOut: sql<number>`SUM(${loteTotalStats.countOut})::int`,
+      lastTs: sql<string | null>`MAX(${loteTotalStats.lastTs})`,
     })
-    .from(loteStats)
-    .innerJoin(dispositivo, eq(dispositivo.id, loteStats.dispositivoId))
-    .where(eq(loteStats.loteId, loteId))
-    .groupBy(loteStats.dispositivoId, dispositivo.nombre);
+    .from(loteTotalStats)
+    .innerJoin(dispositivo, eq(dispositivo.id, loteTotalStats.dispositivoId))
+    .where(eq(loteTotalStats.loteId, loteId))
+    .groupBy(loteTotalStats.dispositivoId, dispositivo.nombre);
 
   // 7. Check if any service uses cajas
   const servicioIds = lifecycle.map((l) => l.servicioId);

--- a/my-project/src/app/api/lotes/global/query.ts
+++ b/my-project/src/app/api/lotes/global/query.ts
@@ -2,7 +2,7 @@ import { db } from "@/db";
 import {
   lote,
   loteServicio,
-  loteStats,
+  loteTotalStats,
   loteSession,
   servicio,
   variedad,
@@ -495,14 +495,14 @@ export async function getGlobalLotesPayload(
       .where(inArray(lote.id, uniqueLoteIds)),
     db
       .select({
-        loteId: loteStats.loteId,
-        totalBulbs: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-        firstTs: sql<Date | null>`MIN(${loteStats.firstTs})`,
-        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+        loteId: loteTotalStats.loteId,
+        totalBulbs: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+        firstTs: sql<Date | null>`MIN(${loteTotalStats.firstTs})`,
+        lastTs: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
       })
-      .from(loteStats)
-      .where(inArray(loteStats.loteId, uniqueLoteIds))
-      .groupBy(loteStats.loteId),
+      .from(loteTotalStats)
+      .where(inArray(loteTotalStats.loteId, uniqueLoteIds))
+      .groupBy(loteTotalStats.loteId),
     db
       .select({ loteId: loteSession.loteId })
       .from(loteSession)

--- a/my-project/src/app/api/lotes/summary/all/route.ts
+++ b/my-project/src/app/api/lotes/summary/all/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { lote, loteStats, loteServicio, servicio } from "@/db/schema";
+import { lote, loteTotalStats, loteServicio, servicio } from "@/db/schema";
 import { and, eq, inArray, desc, sql } from "drizzle-orm";
 
 export async function GET(request: Request) {
@@ -42,17 +42,20 @@ export async function GET(request: Request) {
     .select({
       id: lote.id,
       codigoLote: lote.codigoLote,
-      conteo: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-      firstTimestamp: sql<Date | null>`MIN(${loteStats.firstTs})`,
-      lastTimestamp: sql<Date | null>`MAX(${loteStats.lastTs})`,
+      conteo: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+      firstTimestamp: sql<Date | null>`MIN(${loteTotalStats.firstTs})`,
+      lastTimestamp: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
       createdAt: lote.createdAt,
     })
     .from(lote)
     .leftJoin(
-      loteStats,
+      loteTotalStats,
       servicioId
-        ? and(eq(loteStats.loteId, lote.id), eq(loteStats.servicioId, servicioId))
-        : eq(loteStats.loteId, lote.id)
+        ? and(
+            eq(loteTotalStats.loteId, lote.id),
+            eq(loteTotalStats.servicioId, servicioId)
+          )
+        : eq(loteTotalStats.loteId, lote.id)
     )
     .where(inArray(lote.id, uniqueLoteIds))
     .groupBy(lote.id, lote.codigoLote, lote.createdAt)

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -1,7 +1,7 @@
 // app/api/lotes/summary/route.ts
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { loteStats, dispositivo } from "@/db/schema";
+import { loteTotalStats, dispositivo } from "@/db/schema";
 import { eq, sql } from "drizzle-orm";
 
 export async function GET(request: Request) {
@@ -14,15 +14,15 @@ export async function GET(request: Request) {
   const rows = await db
     .select({
       dispositivoNombre: dispositivo.nombre,
-      servicioId: loteStats.servicioId,
-      countIn: sql<number>`SUM(${loteStats.countIn})::int`,
-      countOut: sql<number>`SUM(${loteStats.countOut})::int`,
-      lastTimestamp: sql<Date>`MAX(${loteStats.lastTs})`,
+      servicioId: loteTotalStats.servicioId,
+      countIn: sql<number>`SUM(${loteTotalStats.countIn})::int`,
+      countOut: sql<number>`SUM(${loteTotalStats.countOut})::int`,
+      lastTimestamp: sql<Date>`MAX(${loteTotalStats.lastTs})`,
     })
-    .from(loteStats)
-    .innerJoin(dispositivo, eq(dispositivo.id, loteStats.dispositivoId))
-    .where(eq(loteStats.loteId, loteId))
-    .groupBy(dispositivo.nombre, loteStats.servicioId);
+    .from(loteTotalStats)
+    .innerJoin(dispositivo, eq(dispositivo.id, loteTotalStats.dispositivoId))
+    .where(eq(loteTotalStats.loteId, loteId))
+    .groupBy(dispositivo.nombre, loteTotalStats.servicioId);
 
   const result = rows.map((r) => ({
     dispositivo: r.dispositivoNombre,

--- a/my-project/src/app/api/procesos/[procesoId]/servicios-detail/route.ts
+++ b/my-project/src/app/api/procesos/[procesoId]/servicios-detail/route.ts
@@ -4,7 +4,7 @@ import {
   servicio,
   loteServicio,
   loteSession,
-  loteStats,
+  loteTotalStats,
   lote,
   variedad,
   producto,
@@ -81,19 +81,19 @@ export async function GET(
     allLoteIds.length > 0
       ? await db
           .select({
-            loteId: loteStats.loteId,
-            servicioId: loteStats.servicioId,
-            totalCount: sql<number>`SUM(${loteStats.countIn} + ${loteStats.countOut})::int`,
-            lastTs: sql<string | null>`MAX(${loteStats.lastTs})`,
+            loteId: loteTotalStats.loteId,
+            servicioId: loteTotalStats.servicioId,
+            totalCount: sql<number>`SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut})::int`,
+            lastTs: sql<string | null>`MAX(${loteTotalStats.lastTs})`,
           })
-          .from(loteStats)
+          .from(loteTotalStats)
           .where(
             and(
-              inArray(loteStats.loteId, allLoteIds),
-              inArray(loteStats.servicioId, servicioIds)
+              inArray(loteTotalStats.loteId, allLoteIds),
+              inArray(loteTotalStats.servicioId, servicioIds)
             )
           )
-          .groupBy(loteStats.loteId, loteStats.servicioId)
+          .groupBy(loteTotalStats.loteId, loteTotalStats.servicioId)
       : [];
 
   const statsMap = new Map<string, { totalCount: number; lastTs: string | null }>();

--- a/my-project/src/app/api/servicios/[servicioId]/detail/route.ts
+++ b/my-project/src/app/api/servicios/[servicioId]/detail/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/db";
 import {
   servicio,
   lote,
-  loteStats,
+  loteTotalStats,
   loteSession,
   loteServicio,
   dispositivo,
@@ -86,15 +86,18 @@ export async function GET(
         id: lote.id,
         codigoLote: lote.codigoLote,
         createdAt: lote.createdAt,
-        totalCount: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+        totalCount: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+        lastTs: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
         variedadNombre: variedad.nombre,
         productoNombre: producto.nombre,
       })
       .from(lote)
       .leftJoin(
-        loteStats,
-        and(eq(loteStats.loteId, lote.id), eq(loteStats.servicioId, servicioId))
+        loteTotalStats,
+        and(
+          eq(loteTotalStats.loteId, lote.id),
+          eq(loteTotalStats.servicioId, servicioId)
+        )
       )
       .leftJoin(variedad, eq(variedad.id, lote.variedadId))
       .leftJoin(producto, eq(producto.id, variedad.productoId))
@@ -133,13 +136,13 @@ export async function GET(
   if (loteIds.length > 0) {
     const [totalRow] = await db
       .select({
-        totalCount: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
+        totalCount: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
       })
-      .from(loteStats)
+      .from(loteTotalStats)
       .where(
         and(
-          inArray(loteStats.loteId, loteIds),
-          eq(loteStats.servicioId, servicioId)
+          inArray(loteTotalStats.loteId, loteIds),
+          eq(loteTotalStats.servicioId, servicioId)
         )
       );
     totalCount = totalRow?.totalCount ?? 0;

--- a/my-project/src/app/api/servicios/[servicioId]/lotes/export/route.ts
+++ b/my-project/src/app/api/servicios/[servicioId]/lotes/export/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { lote, loteServicio, loteStats, producto, variedad } from "@/db/schema";
+import {
+  lote,
+  loteServicio,
+  loteStats,
+  loteTotalStats,
+  producto,
+  variedad,
+} from "@/db/schema";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 
 interface ExportAccumulator {
@@ -11,6 +18,7 @@ interface ExportAccumulator {
   fechaInicio: Date | null;
   fechaTermino: Date | null;
   conteoTotal: number;
+  calibreConteoTotal: number;
   weightedSum: number;
   weightedSquareSum: number;
   distribution: Map<number, number>;
@@ -56,19 +64,37 @@ export async function GET(
       fechaInicio: null,
       fechaTermino: null,
       conteoTotal: 0,
+      calibreConteoTotal: 0,
       weightedSum: 0,
       weightedSquareSum: 0,
       distribution: new Map(),
     });
   }
 
+  const totalRows = await db
+    .select({
+      loteId: loteTotalStats.loteId,
+      count: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+      firstTs: sql<Date | null>`MIN(${loteTotalStats.firstTs})`,
+      lastTs: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
+    })
+    .from(loteTotalStats)
+    .where(
+      and(
+        eq(loteTotalStats.servicioId, servicioId),
+        inArray(
+          loteTotalStats.loteId,
+          loteRows.map((row) => row.loteId)
+        )
+      )
+    )
+    .groupBy(loteTotalStats.loteId);
+
   const statsRows = await db
     .select({
       loteId: loteStats.loteId,
       calibre: loteStats.calibre,
       count: sql<number>`(${loteStats.countIn} + ${loteStats.countOut})::int`,
-      firstTs: loteStats.firstTs,
-      lastTs: loteStats.lastTs,
     })
     .from(loteStats)
     .where(
@@ -83,6 +109,20 @@ export async function GET(
 
   const buckets = new Set<number>();
 
+  for (const total of totalRows) {
+    const acc = accumulators.get(total.loteId);
+    if (!acc) continue;
+
+    acc.conteoTotal = Number(total.count) || 0;
+
+    if (total.firstTs && (!acc.fechaInicio || total.firstTs < acc.fechaInicio)) {
+      acc.fechaInicio = total.firstTs;
+    }
+    if (total.lastTs && (!acc.fechaTermino || total.lastTs > acc.fechaTermino)) {
+      acc.fechaTermino = total.lastTs;
+    }
+  }
+
   for (const stat of statsRows) {
     const acc = accumulators.get(stat.loteId);
     if (!acc) continue;
@@ -94,17 +134,10 @@ export async function GET(
     const bucket = Math.floor(calibre);
     buckets.add(bucket);
 
-    acc.conteoTotal += count;
+    acc.calibreConteoTotal += count;
     acc.weightedSum += calibre * count;
     acc.weightedSquareSum += calibre * calibre * count;
     acc.distribution.set(bucket, (acc.distribution.get(bucket) ?? 0) + count);
-
-    if (stat.firstTs && (!acc.fechaInicio || stat.firstTs < acc.fechaInicio)) {
-      acc.fechaInicio = stat.firstTs;
-    }
-    if (stat.lastTs && (!acc.fechaTermino || stat.lastTs > acc.fechaTermino)) {
-      acc.fechaTermino = stat.lastTs;
-    }
   }
 
   const calibreRanges = Array.from(buckets)
@@ -117,11 +150,13 @@ export async function GET(
   const rows = loteRows.map((loteRow) => {
     const acc = accumulators.get(loteRow.loteId)!;
     const mean =
-      acc.conteoTotal > 0 ? acc.weightedSum / acc.conteoTotal : null;
+      acc.calibreConteoTotal > 0
+        ? acc.weightedSum / acc.calibreConteoTotal
+        : null;
     const variance =
       mean === null
         ? null
-        : acc.weightedSquareSum / acc.conteoTotal - mean * mean;
+        : acc.weightedSquareSum / acc.calibreConteoTotal - mean * mean;
     const desviacionEstandar =
       variance === null ? null : Math.sqrt(Math.max(variance, 0));
 

--- a/my-project/src/app/api/servicios/summary/route.ts
+++ b/my-project/src/app/api/servicios/summary/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/db";
 import {
   servicio,
   lote,
-  loteStats,
+  loteTotalStats,
   loteSession,
   loteServicio,
   dispositivoServicio,
@@ -58,15 +58,15 @@ export async function GET(request: Request) {
     .select({
       servicioId: loteServicio.servicioId,
       loteCount: sql<number>`COUNT(DISTINCT ${loteServicio.loteId})::int`,
-      totalCount: sql<number>`COALESCE(SUM(${loteStats.countIn} + ${loteStats.countOut}), 0)::int`,
-      lastActivity: sql<Date | null>`MAX(${loteStats.lastTs})`,
+      totalCount: sql<number>`COALESCE(SUM(${loteTotalStats.countIn} + ${loteTotalStats.countOut}), 0)::int`,
+      lastActivity: sql<Date | null>`MAX(${loteTotalStats.lastTs})`,
     })
     .from(loteServicio)
     .leftJoin(
-      loteStats,
+      loteTotalStats,
       and(
-        eq(loteStats.loteId, loteServicio.loteId),
-        eq(loteStats.servicioId, loteServicio.servicioId)
+        eq(loteTotalStats.loteId, loteServicio.loteId),
+        eq(loteTotalStats.servicioId, loteServicio.servicioId)
       )
     )
     .where(inArray(loteServicio.servicioId, servicioIds))

--- a/my-project/src/db/schema.ts
+++ b/my-project/src/db/schema.ts
@@ -516,6 +516,29 @@ export const cajaStatsRelations = relations(cajaStats, ({ one }) => ({
   }),
 }));
 
+// ─── Caja Total Stats (resumen por caja/dispositivo, incluye sin calibre) ────
+
+export const cajaTotalStats = pgTable(
+  "caja_total_stats",
+  {
+    cajaLoteSessionId: uuid("caja_lote_session_id")
+      .notNull()
+      .references(() => cajaLoteSession.id, { onDelete: "cascade" }),
+    dispositivoId: uuid("dispositivo_id")
+      .notNull()
+      .references(() => dispositivo.id),
+    countIn: integer("count_in").notNull().default(0),
+    countOut: integer("count_out").notNull().default(0),
+    firstTs: timestamp("first_ts", { withTimezone: true }),
+    lastTs: timestamp("last_ts", { withTimezone: true }),
+  },
+  (t) => [
+    primaryKey({
+      columns: [t.cajaLoteSessionId, t.dispositivoId],
+    }),
+  ]
+);
+
 // ─── Lote Stats (resumen pre-calculado por lote/servicio/dispositivo/calibre) ──
 
 export const loteStats = pgTable(
@@ -539,6 +562,32 @@ export const loteStats = pgTable(
   (t) => [
     primaryKey({
       columns: [t.loteId, t.servicioId, t.dispositivoId, t.calibre],
+    }),
+  ]
+);
+
+// ─── Lote Total Stats (resumen por lote/servicio/dispositivo, incluye sin calibre) ──
+
+export const loteTotalStats = pgTable(
+  "lote_total_stats",
+  {
+    loteId: uuid("lote_id")
+      .notNull()
+      .references(() => lote.id, { onDelete: "cascade" }),
+    servicioId: uuid("servicio_id")
+      .notNull()
+      .references(() => servicio.id),
+    dispositivoId: uuid("dispositivo_id")
+      .notNull()
+      .references(() => dispositivo.id),
+    countIn: integer("count_in").notNull().default(0),
+    countOut: integer("count_out").notNull().default(0),
+    firstTs: timestamp("first_ts", { withTimezone: true }),
+    lastTs: timestamp("last_ts", { withTimezone: true }),
+  },
+  (t) => [
+    primaryKey({
+      columns: [t.loteId, t.servicioId, t.dispositivoId],
     }),
   ]
 );


### PR DESCRIPTION
## Summary
- Agrega tablas `lote_total_stats` y `caja_total_stats` que acumulan conteos sin importar si el conteo tiene `perimeter` o no
- `conteoTotal` ahora refleja **todas** las mediciones (con y sin calibre); distribución y promedios siguen usando solo las calibradas
- Migración `0018` incluye: creación de tablas, backfill de datos históricos, `perimeter` pasa a nullable en `conteo`, y trigger `update_lote_stats` actualizado

## Test plan
- [ ] Verificar que `conteoTotal` en lote/caja aumenta con mediciones sin calibre
- [ ] Verificar que distribución de calibres no cambia
- [ ] Verificar que el export de lotes incluye el total correcto
- [ ] Confirmar que sync de mediciones sin `perimeter` no falla

🤖 Generated with [Claude Code](https://claude.com/claude-code)