### PR TITLE
fix: conteos sin perímetro ya se contabilizan en totales de servicios

### DIFF
--- a/my-project/drizzle/0018_null_calibre.sql
+++ b/my-project/drizzle/0018_null_calibre.sql
@@ -1,0 +1,26 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migración 0018: calibre nullable en lote_stats y caja_stats
+--
+-- Problema: el trigger insertaba calibre = ROUND(NULL) = NULL, pero ambas
+-- tablas tenían calibre NOT NULL (parte de la primary key), lo que causaba
+-- que la transacción se revirtiera y los conteos sin perímetro nunca se
+-- guardaran. Los totales de servicios con perímetro apagado quedaban en 0.
+--
+-- Solución: eliminar la primary key implícita (que fuerza NOT NULL), hacer
+-- calibre nullable, y agregar un índice único NULLS NOT DISTINCT para que
+-- el ON CONFLICT del trigger trate dos NULL del mismo grupo como conflicto.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- lote_stats
+ALTER TABLE "lote_stats" DROP CONSTRAINT "lote_stats_lote_id_servicio_id_dispositivo_id_calibre_pk";
+ALTER TABLE "lote_stats" ALTER COLUMN "calibre" DROP NOT NULL;
+CREATE UNIQUE INDEX "lote_stats_unique_key"
+  ON "lote_stats" ("lote_id", "servicio_id", "dispositivo_id", "calibre")
+  NULLS NOT DISTINCT;
+
+-- caja_stats
+ALTER TABLE "caja_stats" DROP CONSTRAINT "caja_stats_caja_lote_session_id_dispositivo_id_calibre_pk";
+ALTER TABLE "caja_stats" ALTER COLUMN "calibre" DROP NOT NULL;
+CREATE UNIQUE INDEX "caja_stats_unique_key"
+  ON "caja_stats" ("caja_lote_session_id", "dispositivo_id", "calibre")
+  NULLS NOT DISTINCT;

--- a/my-project/src/app/api/servicios/[servicioId]/lotes/export/route.ts
+++ b/my-project/src/app/api/servicios/[servicioId]/lotes/export/route.ts
@@ -89,7 +89,7 @@ export async function GET(
 
     const count = Number(stat.count) || 0;
     const calibre = Number(stat.calibre);
-    if (count <= 0 || !Number.isFinite(calibre)) continue;
+    if (count <= 0 || stat.calibre == null || !Number.isFinite(calibre)) continue;
 
     const bucket = Math.floor(calibre);
     buckets.add(bucket);

--- a/my-project/src/app/api/stats/distribution/route.ts
+++ b/my-project/src/app/api/stats/distribution/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: Request) {
   for (const loteId of loteIds) {
     const points = resultByLote[loteId] ?? [];
     for (const point of points) {
-      if (point.perimeter == null || isNaN(point.perimeter)) continue;
+      if (point.perimeter == null || isNaN(point.perimeter) || point.perimeter <= 0) continue;
       const key = Number(point.perimeter.toFixed(1));
       const entry = perimeterMap.get(key) ?? { perimeter: key };
       entry[loteId] = point.count;

--- a/my-project/src/db/schema.ts
+++ b/my-project/src/db/schema.ts
@@ -10,6 +10,7 @@ import {
   doublePrecision,
   jsonb,
   primaryKey,
+  uniqueIndex,
   index,
   integer,
 } from "drizzle-orm/pg-core";
@@ -492,16 +493,16 @@ export const cajaStats = pgTable(
     dispositivoId: uuid("dispositivo_id")
       .notNull()
       .references(() => dispositivo.id),
-    calibre: real("calibre").notNull(),
+    calibre: real("calibre"),
     countIn: integer("count_in").notNull().default(0),
     countOut: integer("count_out").notNull().default(0),
     firstTs: timestamp("first_ts", { withTimezone: true }),
     lastTs: timestamp("last_ts", { withTimezone: true }),
   },
   (t) => [
-    primaryKey({
-      columns: [t.cajaLoteSessionId, t.dispositivoId, t.calibre],
-    }),
+    uniqueIndex("caja_stats_unique_key").on(
+      t.cajaLoteSessionId, t.dispositivoId, t.calibre
+    ),
   ]
 );
 
@@ -530,16 +531,16 @@ export const loteStats = pgTable(
     dispositivoId: uuid("dispositivo_id")
       .notNull()
       .references(() => dispositivo.id),
-    calibre: real("calibre").notNull(),
+    calibre: real("calibre"),
     countIn: integer("count_in").notNull().default(0),
     countOut: integer("count_out").notNull().default(0),
     firstTs: timestamp("first_ts", { withTimezone: true }),
     lastTs: timestamp("last_ts", { withTimezone: true }),
   },
   (t) => [
-    primaryKey({
-      columns: [t.loteId, t.servicioId, t.dispositivoId, t.calibre],
-    }),
+    uniqueIndex("lote_stats_unique_key").on(
+      t.loteId, t.servicioId, t.dispositivoId, t.calibre
+    ),
   ]
 );
 


### PR DESCRIPTION
## Problema

Migration 0017 hizo `conteo.perimeter` nullable para soportar servicios sin medición de perímetro. Sin embargo, el trigger `update_lote_stats()` calculaba `calibre = ROUND(NULL) = NULL` e intentaba insertarlo en `lote_stats`/`caja_stats` donde `calibre` era `NOT NULL` (parte de la primary key). La transacción se revertía completa — los conteos sin perímetro **nunca se guardaban**, y los totales de servicios quedaban en 0.

## Solución

- Eliminar la primary key implícita de `lote_stats` y `caja_stats`
- Hacer `calibre` nullable en ambas tablas
- Crear índice único `NULLS NOT DISTINCT` para que el `ON CONFLICT` del trigger fusione correctamente filas con `calibre = NULL`
- Filtrar `calibre <= 0` y `calibre IS NULL` en el gráfico de distribución y export (no tiene sentido mostrar una barra "sin calibre")

El trigger no requirió cambios — `ROUND(NULL) = NULL` es semánticamente correcto.

## Archivos

- `drizzle/0018_null_calibre.sql` — migración DDL (ya aplicada a la DB)
- `src/db/schema.ts` — calibre nullable, primaryKey → uniqueIndex
- `src/app/api/stats/distribution/route.ts` — filtro `<= 0`
- `src/app/api/servicios/[servicioId]/lotes/export/route.ts` — filtro `== null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)