### PR TITLE
feat: rediseño completo de la sección Analítica

### DIFF
--- a/my-project/src/app/api/analitica/lote-evolucion/route.ts
+++ b/my-project/src/app/api/analitica/lote-evolucion/route.ts
@@ -20,13 +20,13 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get the lote's service assignments with process context, ordered
   const steps = await db
     .select({
       servicioId: loteServicio.servicioId,
       asignadoAt: loteServicio.asignadoAt,
       servicioNombre: servicio.nombre,
       tipoProcesoNombre: tipoProceso.nombre,
+      procesoTemporada: proceso.temporada,
     })
     .from(loteServicio)
     .innerJoin(servicio, eq(servicio.id, loteServicio.servicioId))
@@ -35,11 +35,10 @@ export async function GET(request: Request) {
     .where(eq(loteServicio.loteId, loteId))
     .orderBy(loteServicio.asignadoAt);
 
-  // For each step, get caliber distribution
   const stepsWithDistribution = [];
 
   for (const step of steps) {
-    const distribution = await db
+    const distributionRows = await db
       .select({
         calibre: loteStats.calibre,
         count: sql<number>`SUM(${loteStats.countIn} + ${loteStats.countOut})::int`,
@@ -54,7 +53,20 @@ export async function GET(request: Request) {
       .groupBy(loteStats.calibre)
       .orderBy(loteStats.calibre);
 
-    const distributionWithCalibre = distribution.filter(
+    const [tsRow] = await db
+      .select({
+        firstTs: sql<Date | null>`MIN(${loteStats.firstTs})`,
+        lastTs: sql<Date | null>`MAX(${loteStats.lastTs})`,
+      })
+      .from(loteStats)
+      .where(
+        and(
+          eq(loteStats.loteId, loteId),
+          eq(loteStats.servicioId, step.servicioId)
+        )
+      );
+
+    const distributionWithCalibre = distributionRows.filter(
       (d): d is typeof d & { calibre: number } => d.calibre != null
     );
     const totalCount = distributionWithCalibre.reduce((sum, d) => sum + d.count, 0);
@@ -69,13 +81,17 @@ export async function GET(request: Request) {
     );
     const variance = totalCount > 0 ? varianceSum / totalCount : 0;
     const stdDev = Math.sqrt(variance);
+    const calibres = distributionWithCalibre.map((d) => d.calibre);
 
     stepsWithDistribution.push({
       servicioId: step.servicioId,
       servicioNombre: step.servicioNombre,
       tipoProcesoNombre: step.tipoProcesoNombre,
+      procesoTemporada: step.procesoTemporada,
       asignadoAt: step.asignadoAt,
-      distribution: distribution.map((d) => ({
+      firstTs: tsRow?.firstTs ? new Date(tsRow.firstTs).toISOString() : null,
+      lastTs: tsRow?.lastTs ? new Date(tsRow.lastTs).toISOString() : null,
+      distribution: distributionRows.map((d) => ({
         calibre: d.calibre,
         count: d.count,
       })),
@@ -84,6 +100,8 @@ export async function GET(request: Request) {
         mean: Math.round(mean * 100) / 100,
         stdDev: Math.round(stdDev * 100) / 100,
         variance: Math.round(variance * 100) / 100,
+        min: calibres.length > 0 ? Math.min(...calibres) : 0,
+        max: calibres.length > 0 ? Math.max(...calibres) : 0,
       },
     });
   }

--- a/my-project/src/app/api/lotes/global/route.ts
+++ b/my-project/src/app/api/lotes/global/route.ts
@@ -15,6 +15,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const payload = await getGlobalLotesPayload(query);
+  const all = searchParams.get("all") === "true";
+  const payload = await getGlobalLotesPayload(query, { paginate: !all });
   return NextResponse.json(payload);
 }

--- a/my-project/src/app/app/analitica/_components/AnaliticaFilters.tsx
+++ b/my-project/src/app/app/analitica/_components/AnaliticaFilters.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React from "react";
+import { Search, EyeOff, Eye, FilterX } from "lucide-react";
+import type { AnaliticaFiltersState, FacetOption } from "./types";
+
+interface Props {
+  state: AnaliticaFiltersState;
+  onChange: (next: AnaliticaFiltersState) => void;
+  productos: FacetOption[];
+  variedades: (FacetOption & { productoId: string | null })[];
+  etapas: FacetOption[];
+  resultCount: number;
+  totalCount: number;
+}
+
+const ACTIVITY_OPTIONS = [
+  { label: "Todos", value: "todos" as const },
+  { label: "Últimos 7 días", value: "ultimos_7" as const },
+  { label: "Últimos 30 días", value: "ultimos_30" as const },
+];
+
+export function AnaliticaFilters({
+  state,
+  onChange,
+  productos,
+  variedades,
+  etapas,
+  resultCount,
+  totalCount,
+}: Props) {
+  const set = <K extends keyof AnaliticaFiltersState>(
+    key: K,
+    value: AnaliticaFiltersState[K]
+  ) => onChange({ ...state, [key]: value });
+
+  const isFiltered =
+    state.search !== "" ||
+    state.productoId !== "" ||
+    state.variedadId !== "" ||
+    state.tipoProcesoId !== "" ||
+    state.activity !== "todos" ||
+    !state.hideEmpty;
+
+  const filteredVariedades =
+    state.productoId === ""
+      ? variedades
+      : variedades.filter((v) => v.productoId === state.productoId);
+
+  return (
+    <div className="rounded-xl bg-slate-900/40 border border-white/10 p-3 md:p-4 space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[220px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+          <input
+            type="text"
+            placeholder="Buscar lote, variedad, producto…"
+            value={state.search}
+            onChange={(e) => set("search", e.target.value)}
+            className="w-full pl-9 pr-3 py-1.5 rounded-full text-sm bg-slate-950/50 border border-white/10 text-white placeholder:text-slate-500 focus:outline-none focus:border-cyan-500/40"
+          />
+        </div>
+
+        <FilterSelect
+          value={state.productoId}
+          onChange={(v) => {
+            const next = { ...state, productoId: v };
+            if (
+              v &&
+              state.variedadId &&
+              !variedades.find(
+                (var_) => var_.id === state.variedadId && var_.productoId === v
+              )
+            ) {
+              next.variedadId = "";
+            }
+            onChange(next);
+          }}
+          placeholder="Todos los productos"
+          options={productos}
+        />
+        <FilterSelect
+          value={state.variedadId}
+          onChange={(v) => set("variedadId", v)}
+          placeholder="Todas las variedades"
+          options={filteredVariedades}
+        />
+        <FilterSelect
+          value={state.tipoProcesoId}
+          onChange={(v) => set("tipoProcesoId", v)}
+          placeholder="Todas las etapas"
+          options={etapas}
+        />
+
+        <div className="flex gap-1.5">
+          {ACTIVITY_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => set("activity", opt.value)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+                state.activity === opt.value
+                  ? "bg-cyan-950/60 text-cyan-400 border-cyan-500/40"
+                  : "bg-slate-900/40 text-slate-400 border-white/10 hover:border-white/20 hover:text-slate-300"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={() => set("hideEmpty", !state.hideEmpty)}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors ${
+            state.hideEmpty
+              ? "bg-slate-900/40 text-slate-400 border-white/10 hover:border-white/20 hover:text-slate-300"
+              : "bg-amber-950/40 text-amber-300 border-amber-500/30"
+          }`}
+          title={state.hideEmpty ? "Mostrar lotes sin datos" : "Ocultar lotes sin datos"}
+        >
+          {state.hideEmpty ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+          {state.hideEmpty ? "Sin datos ocultos" : "Mostrando sin datos"}
+        </button>
+
+        {isFiltered && (
+          <button
+            onClick={() =>
+              onChange({
+                search: "",
+                productoId: "",
+                variedadId: "",
+                tipoProcesoId: "",
+                hideEmpty: true,
+                activity: "todos",
+              })
+            }
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-slate-900/40 text-slate-400 border border-white/10 hover:border-red-500/30 hover:text-red-300 transition-colors"
+          >
+            <FilterX className="w-3.5 h-3.5" />
+            Limpiar
+          </button>
+        )}
+      </div>
+
+      <div className="text-[11px] text-slate-500">
+        Mostrando <span className="text-slate-300 font-medium">{resultCount}</span> de{" "}
+        <span className="text-slate-400">{totalCount}</span> lotes
+      </div>
+    </div>
+  );
+}
+
+function FilterSelect({
+  value,
+  onChange,
+  placeholder,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  options: FacetOption[];
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="appearance-none pl-3 pr-7 py-1.5 rounded-full text-xs font-medium bg-slate-900/40 text-slate-300 border border-white/10 hover:border-white/20 focus:outline-none focus:border-cyan-500/40 cursor-pointer"
+    >
+      <option value="">{placeholder}</option>
+      {options.map((opt) => (
+        <option key={opt.id} value={opt.id}>
+          {opt.nombre} ({opt.count})
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/my-project/src/app/app/analitica/_components/EmptyState.tsx
+++ b/my-project/src/app/app/analitica/_components/EmptyState.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import type { LucideIcon } from "lucide-react";
+
+interface Props {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({ icon: Icon, title, description, action }: Props) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-14 px-6 rounded-xl bg-slate-900/30 border border-dashed border-white/10">
+      <div className="w-12 h-12 rounded-full bg-slate-800/60 border border-white/10 flex items-center justify-center mb-3">
+        <Icon className="w-5 h-5 text-slate-400" />
+      </div>
+      <p className="text-sm font-medium text-slate-200">{title}</p>
+      {description && (
+        <p className="mt-1 text-xs text-slate-500 max-w-sm">{description}</p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/my-project/src/app/app/analitica/_components/KpiCard.tsx
+++ b/my-project/src/app/app/analitica/_components/KpiCard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import type { LucideIcon } from "lucide-react";
+
+interface KpiCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  accent?: "cyan" | "emerald" | "orange" | "indigo";
+  hint?: string;
+}
+
+const ACCENTS = {
+  cyan: { icon: "text-cyan-400", value: "text-cyan-300" },
+  emerald: { icon: "text-emerald-400", value: "text-emerald-300" },
+  orange: { icon: "text-orange-400", value: "text-orange-300" },
+  indigo: { icon: "text-indigo-400", value: "text-indigo-300" },
+};
+
+export function KpiCard({ icon: Icon, label, value, accent = "cyan", hint }: KpiCardProps) {
+  const styles = ACCENTS[accent];
+  return (
+    <Card className="bg-slate-900/40 border-white/10">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Icon className={`w-4 h-4 ${styles.icon}`} />
+          <p className="text-xs uppercase tracking-wide text-slate-500">{label}</p>
+        </div>
+        <p className={`text-2xl font-bold ${styles.value} font-mono`}>{value}</p>
+        {hint && <p className="text-xs text-slate-500 mt-1">{hint}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/my-project/src/app/app/analitica/_components/LoteCombobox.tsx
+++ b/my-project/src/app/app/analitica/_components/LoteCombobox.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import { Check, ChevronsUpDown, Package2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  displayLoteCode,
+  formatNumber,
+  relativeTimeEs,
+  normalizeText,
+  type LoteOption,
+} from "./types";
+
+interface LoteComboboxProps {
+  options: LoteOption[];
+  value: string;
+  onChange: (id: string) => void;
+  placeholder?: string;
+  excludeIds?: string[];
+  className?: string;
+}
+
+export function LoteCombobox({
+  options,
+  value,
+  onChange,
+  placeholder = "Buscar lote por código, variedad o producto…",
+  excludeIds = [],
+  className,
+}: LoteComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  const ordered = useMemo(() => {
+    const excluded = new Set(excludeIds);
+    return [...options]
+      .filter((l) => !excluded.has(l.id))
+      .sort((a, b) => {
+        const aEmpty = a.totalBulbs === 0 && !a.lastTs;
+        const bEmpty = b.totalBulbs === 0 && !b.lastTs;
+        if (aEmpty !== bEmpty) return aEmpty ? 1 : -1;
+        const aTime = a.lastTs ? new Date(a.lastTs).getTime() : 0;
+        const bTime = b.lastTs ? new Date(b.lastTs).getTime() : 0;
+        return bTime - aTime;
+      });
+  }, [options, excludeIds]);
+
+  const selected = options.find((l) => l.id === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-expanded={open}
+          className={cn(
+            "flex items-center justify-between gap-2 w-full max-w-md px-3 py-2 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-left hover:border-white/20 focus:outline-none focus:border-cyan-500/40 transition-colors",
+            className
+          )}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <Package2 className="w-4 h-4 text-slate-500 shrink-0" />
+            {selected ? (
+              <span className="flex items-center gap-2 min-w-0">
+                <span className="font-mono text-white truncate">
+                  {displayLoteCode(selected)}
+                </span>
+                {selected.variedadNombre && (
+                  <span className="text-slate-500 truncate">
+                    · {selected.variedadNombre}
+                  </span>
+                )}
+              </span>
+            ) : (
+              <span className="text-slate-500 truncate">{placeholder}</span>
+            )}
+          </div>
+          <ChevronsUpDown className="w-4 h-4 text-slate-500 shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[var(--radix-popover-trigger-width)] p-0 bg-slate-950 border-white/10"
+      >
+        <Command
+          className="bg-transparent"
+          filter={(itemValue, search) => {
+            const lote = ordered.find((l) => l.id === itemValue);
+            if (!lote) return 0;
+            const hay = normalizeText(
+              [
+                lote.codigoLote,
+                lote.variedadNombre,
+                lote.productoNombre,
+                lote.servicioActual,
+                lote.etapaActual,
+              ].join(" ")
+            );
+            const needle = normalizeText(search);
+            return hay.includes(needle) ? 1 : 0;
+          }}
+        >
+          <CommandInput
+            placeholder="Buscar…"
+            className="text-white placeholder:text-slate-500"
+          />
+          <CommandList className="max-h-[360px]">
+            <CommandEmpty className="text-slate-500">
+              No se encontraron lotes.
+            </CommandEmpty>
+            <CommandGroup>
+              {ordered.map((lote) => {
+                const isEmpty = lote.totalBulbs === 0 && !lote.lastTs;
+                const isSelected = lote.id === value;
+                return (
+                  <CommandItem
+                    key={lote.id}
+                    value={lote.id}
+                    onSelect={() => {
+                      onChange(lote.id);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "flex flex-col items-start gap-0.5 py-2 px-3 cursor-pointer data-[selected=true]:bg-cyan-500/10",
+                      isEmpty && "opacity-60"
+                    )}
+                  >
+                    <div className="flex items-center gap-2 w-full">
+                      <Check
+                        className={cn(
+                          "w-3.5 h-3.5 text-cyan-400 shrink-0",
+                          isSelected ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      <span className="font-mono text-sm text-white">
+                        {displayLoteCode(lote)}
+                      </span>
+                      {lote.variedadNombre && (
+                        <span className="text-xs text-slate-400 truncate">
+                          · {lote.variedadNombre}
+                        </span>
+                      )}
+                      {lote.productoNombre && (
+                        <span className="text-[11px] text-slate-500 truncate">
+                          · {lote.productoNombre}
+                        </span>
+                      )}
+                      <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                        {isEmpty ? (
+                          <Badge className="text-[10px] py-0 px-1.5 bg-amber-500/10 text-amber-300 border-amber-500/30 hover:bg-amber-500/10">
+                            Sin datos
+                          </Badge>
+                        ) : lote.isActive ? (
+                          <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.7)]" />
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="pl-6 text-[11px] text-slate-500 flex items-center gap-1.5 flex-wrap">
+                      <span>{lote.etapaActual ?? "Sin etapa"}</span>
+                      {lote.servicioActual && (
+                        <>
+                          <span className="text-slate-700">·</span>
+                          <span>{lote.servicioActual}</span>
+                        </>
+                      )}
+                      <span className="text-slate-700">·</span>
+                      <span>{formatNumber(lote.totalBulbs)} bulbos</span>
+                      <span className="text-slate-700">·</span>
+                      <span>{relativeTimeEs(lote.lastTs)}</span>
+                    </div>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/my-project/src/app/app/analitica/_components/LoteContextCard.tsx
+++ b/my-project/src/app/app/analitica/_components/LoteContextCard.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Package, Layers, Activity, Calendar, Sprout } from "lucide-react";
+import {
+  formatDateShort,
+  formatNumber,
+  relativeTimeEs,
+  type LoteOption,
+} from "./types";
+
+export function LoteContextCard({ lote }: { lote: LoteOption }) {
+  const code = lote.codigoLote?.trim() || "Sin código";
+  const hasData = lote.totalBulbs > 0 || !!lote.lastTs;
+
+  return (
+    <Card className="bg-gradient-to-br from-slate-900/60 to-slate-900/30 border-white/10">
+      <CardContent className="p-4 md:p-5">
+        <div className="flex flex-wrap items-start gap-x-6 gap-y-3 justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-mono text-lg font-semibold text-white tracking-tight">
+                {code}
+              </span>
+              {lote.isActive ? (
+                <Badge className="bg-emerald-500/15 text-emerald-300 border-emerald-500/30 hover:bg-emerald-500/15">
+                  Activo
+                </Badge>
+              ) : (
+                <Badge className="bg-slate-700/40 text-slate-400 border-slate-600/40 hover:bg-slate-700/40">
+                  Inactivo
+                </Badge>
+              )}
+              {!hasData && (
+                <Badge className="bg-amber-500/15 text-amber-300 border-amber-500/30 hover:bg-amber-500/15">
+                  Sin datos
+                </Badge>
+              )}
+            </div>
+            <div className="mt-1 text-sm text-slate-400 flex items-center gap-2 flex-wrap">
+              <Sprout className="w-3.5 h-3.5 text-slate-500" />
+              <span>{lote.variedadNombre ?? "Sin variedad"}</span>
+              {lote.productoNombre && (
+                <>
+                  <span className="text-slate-600">·</span>
+                  <span className="text-slate-500">{lote.productoNombre}</span>
+                </>
+              )}
+              {lote.variedadTipo && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] py-0 px-1.5 border-white/10 text-slate-400"
+                >
+                  {lote.variedadTipo}
+                </Badge>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-xs">
+            <Metric icon={Layers} label="Etapa actual" value={lote.etapaActual ?? "—"} sub={lote.servicioActual ?? undefined} />
+            <Metric icon={Package} label="Total bulbos" value={formatNumber(lote.totalBulbs)} />
+            <Metric
+              icon={Activity}
+              label="Última actividad"
+              value={relativeTimeEs(lote.lastTs)}
+              sub={lote.lastTs ? formatDateShort(lote.lastTs) : undefined}
+            />
+            <Metric
+              icon={Calendar}
+              label="Creado"
+              value={formatDateShort(lote.createdAt)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-slate-500">
+        <Icon className="w-3 h-3" />
+        {label}
+      </div>
+      <div className="mt-0.5 text-sm text-white font-medium">{value}</div>
+      {sub && <div className="text-[11px] text-slate-500">{sub}</div>}
+    </div>
+  );
+}

--- a/my-project/src/app/app/analitica/_components/types.ts
+++ b/my-project/src/app/app/analitica/_components/types.ts
@@ -1,0 +1,120 @@
+export interface LoteOption {
+  id: string;
+  codigoLote: string | null;
+  variedadId: string | null;
+  variedadNombre: string | null;
+  variedadTipo: string | null;
+  productoId: string | null;
+  productoNombre: string | null;
+  etapaActualId: string | null;
+  etapaActual: string | null;
+  servicioActualId: string | null;
+  servicioActual: string | null;
+  totalBulbs: number;
+  lastTs: string | null;
+  firstTs: string | null;
+  isActive: boolean;
+  createdAt: string | null;
+}
+
+export interface FacetOption {
+  id: string;
+  nombre: string;
+  count: number;
+}
+
+export interface EvolucionStep {
+  servicioId: string;
+  servicioNombre: string;
+  tipoProcesoNombre: string | null;
+  procesoTemporada: string | null;
+  asignadoAt: string;
+  firstTs: string | null;
+  lastTs: string | null;
+  distribution: { calibre: number | null; count: number }[];
+  stats: {
+    totalCount: number;
+    mean: number;
+    stdDev: number;
+    variance: number;
+    min: number;
+    max: number;
+  };
+}
+
+export interface ComparacionLote {
+  loteId: string;
+  codigoLote: string | null;
+  distribution: { calibre: number | null; count: number }[];
+  stats: {
+    totalCount: number;
+    mean: number;
+    stdDev: number;
+    variance: number;
+    min: number;
+    max: number;
+  };
+}
+
+export interface AnaliticaFiltersState {
+  search: string;
+  productoId: string;
+  variedadId: string;
+  tipoProcesoId: string;
+  hideEmpty: boolean;
+  activity: "todos" | "ultimos_7" | "ultimos_30";
+}
+
+export const COLORS = [
+  "#06b6d4",
+  "#6366f1",
+  "#f97316",
+  "#10b981",
+  "#ec4899",
+  "#eab308",
+] as const;
+
+export function displayLoteCode(lote: { codigoLote?: string | null }): string {
+  return lote.codigoLote?.trim() || "Sin código";
+}
+
+export function formatNumber(n: number): string {
+  return n.toLocaleString("es-CL");
+}
+
+export function relativeTimeEs(iso: string | null): string {
+  if (!iso) return "Sin actividad";
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffMs = now - then;
+  if (diffMs < 0) return "ahora";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "hace un momento";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `hace ${min} min`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `hace ${hr} h`;
+  const d = Math.floor(hr / 24);
+  if (d < 30) return `hace ${d} d`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `hace ${mo} mes${mo > 1 ? "es" : ""}`;
+  const yr = Math.floor(d / 365);
+  return `hace ${yr} año${yr > 1 ? "s" : ""}`;
+}
+
+export function formatDateShort(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleDateString("es-CL", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}

--- a/my-project/src/app/app/analitica/page.tsx
+++ b/my-project/src/app/app/analitica/page.tsx
@@ -105,7 +105,7 @@ export default function AnaliticaPage() {
   useEffect(() => {
     if (!data?.empresaId) return;
     setLoadingLotes(true);
-    fetch(`/api/lotes/global?empresaId=${data.empresaId}&limit=500`)
+    fetch(`/api/lotes/global?empresaId=${data.empresaId}&all=true`)
       .then((res) => res.json())
       .then((json: GlobalLotesResponse) => setPayload(json))
       .catch(console.error)

--- a/my-project/src/app/app/analitica/page.tsx
+++ b/my-project/src/app/app/analitica/page.tsx
@@ -16,65 +16,72 @@ import {
   LineChart,
   Line,
   Legend,
+  ReferenceLine,
+  Cell,
 } from "recharts";
-import { Search, X } from "lucide-react";
+import {
+  TrendingUp,
+  BarChart3,
+  ArrowLeftRight,
+  X,
+  Package,
+  Activity,
+  Layers,
+  Sparkles,
+  Search,
+  Plus,
+} from "lucide-react";
 
-// ---------- Types ----------
+import { LoteCombobox } from "./_components/LoteCombobox";
+import { LoteContextCard } from "./_components/LoteContextCard";
+import { KpiCard } from "./_components/KpiCard";
+import { AnaliticaFilters } from "./_components/AnaliticaFilters";
+import { EmptyState } from "./_components/EmptyState";
+import {
+  COLORS,
+  displayLoteCode,
+  formatNumber,
+  formatDateShort,
+  normalizeText,
+  relativeTimeEs,
+  type AnaliticaFiltersState,
+  type ComparacionLote,
+  type EvolucionStep,
+  type FacetOption,
+  type LoteOption,
+} from "./_components/types";
 
-interface EvolucionStep {
-  servicioId: string;
-  servicioNombre: string;
-  tipoProcesoNombre: string | null;
-  asignadoAt: string;
-  distribution: { calibre: number; count: number }[];
-  stats: {
-    totalCount: number;
-    mean: number;
-    stdDev: number;
-    variance: number;
+interface GlobalLotesResponse {
+  data: LoteOption[];
+  total: number;
+  summary: {
+    active: number;
+    withData: number;
+    totalBulbs: number;
+    lastActivity: string | null;
+  };
+  facets: {
+    productos: FacetOption[];
+    variedades: (FacetOption & { productoId: string | null })[];
+    etapas: FacetOption[];
   };
 }
 
-interface ComparacionLote {
-  loteId: string;
-  codigoLote: string | null;
-  distribution: { calibre: number; count: number }[];
-  stats: {
-    totalCount: number;
-    mean: number;
-    stdDev: number;
-    variance: number;
-    min: number;
-    max: number;
-  };
-}
-
-interface LoteOption {
-  id: string;
-  codigoLote: string | null;
-  variedadNombre: string | null;
-  productoNombre: string | null;
-}
-
-// ---------- Helpers ----------
-
-const COLORS = ["#06b6d4", "#6366f1", "#f97316", "#10b981", "#ec4899", "#eab308"];
-
-function formatNumber(n: number): string {
-  return n.toLocaleString("es-CL");
-}
-
-function displayLote(lote: { codigoLote?: string | null }): string {
-  return lote.codigoLote?.trim() || "Sin código";
-}
-
-// ---------- Main Page ----------
+const DEFAULT_FILTERS: AnaliticaFiltersState = {
+  search: "",
+  productoId: "",
+  variedadId: "",
+  tipoProcesoId: "",
+  hideEmpty: true,
+  activity: "todos",
+};
 
 export default function AnaliticaPage() {
   const { data, loading: authLoading } = useContext(AuthenticationContext);
 
-  // Shared state: lote options
-  const [loteOptions, setLoteOptions] = useState<LoteOption[]>([]);
+  const [payload, setPayload] = useState<GlobalLotesResponse | null>(null);
+  const [loadingLotes, setLoadingLotes] = useState(true);
+  const [filters, setFilters] = useState<AnaliticaFiltersState>(DEFAULT_FILTERS);
 
   // Tab 1: Evolucion
   const [selectedLoteEvo, setSelectedLoteEvo] = useState<string>("");
@@ -94,25 +101,57 @@ export default function AnaliticaPage() {
   const [diffStep2, setDiffStep2] = useState(1);
   const [diffLoading, setDiffLoading] = useState(false);
 
-  // Fetch lote options for search
+  // ── Fetch lotes (global with facets) ──────────────────────────────────────
   useEffect(() => {
     if (!data?.empresaId) return;
-    fetch(`/api/lotes/global?empresaId=${data.empresaId}&limit=100`)
+    setLoadingLotes(true);
+    fetch(`/api/lotes/global?empresaId=${data.empresaId}&limit=500`)
       .then((res) => res.json())
-      .then((json) => {
-        setLoteOptions(
-          json.data?.map((l: LoteOption) => ({
-            id: l.id,
-            codigoLote: l.codigoLote,
-            variedadNombre: l.variedadNombre,
-            productoNombre: l.productoNombre,
-          })) ?? []
-        );
-      })
-      .catch(console.error);
+      .then((json: GlobalLotesResponse) => setPayload(json))
+      .catch(console.error)
+      .finally(() => setLoadingLotes(false));
   }, [data?.empresaId]);
 
-  // ── Tab 1: Fetch evolucion ────────────────────────────────────────────────
+  // Filter lote options client-side
+  const filteredLotes = useMemo(() => {
+    if (!payload) return [];
+    const term = normalizeText(filters.search);
+    const now = Date.now();
+    const activityMs =
+      filters.activity === "ultimos_7"
+        ? 7 * 24 * 60 * 60 * 1000
+        : filters.activity === "ultimos_30"
+        ? 30 * 24 * 60 * 60 * 1000
+        : null;
+
+    return payload.data.filter((l) => {
+      if (filters.productoId && l.productoId !== filters.productoId) return false;
+      if (filters.variedadId && l.variedadId !== filters.variedadId) return false;
+      if (filters.tipoProcesoId && l.etapaActualId !== filters.tipoProcesoId) {
+        return false;
+      }
+      if (filters.hideEmpty && l.totalBulbs === 0 && !l.lastTs) return false;
+      if (activityMs !== null) {
+        if (!l.lastTs) return false;
+        if (now - new Date(l.lastTs).getTime() > activityMs) return false;
+      }
+      if (term) {
+        const hay = normalizeText(
+          [
+            l.codigoLote,
+            l.variedadNombre,
+            l.productoNombre,
+            l.etapaActual,
+            l.servicioActual,
+          ].join(" ")
+        );
+        if (!hay.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [payload, filters]);
+
+  // ── Tab 1: Evolucion fetch ────────────────────────────────────────────────
   useEffect(() => {
     if (!selectedLoteEvo) {
       setEvolucion([]);
@@ -120,66 +159,76 @@ export default function AnaliticaPage() {
     }
     setEvoLoading(true);
     fetch(`/api/analitica/lote-evolucion?loteId=${selectedLoteEvo}`)
-      .then((res) => res.json())
-      .then((data: EvolucionStep[]) => setEvolucion(data))
+      .then((r) => r.json())
+      .then((d: EvolucionStep[]) => setEvolucion(d))
       .catch(console.error)
       .finally(() => setEvoLoading(false));
   }, [selectedLoteEvo]);
 
-  // Evolucion chart data: mean calibre at each step
   const evoChartData = useMemo(() => {
-    return evolucion.map((step) => ({
-      name: step.tipoProcesoNombre ?? step.servicioNombre,
+    return evolucion.map((step, idx) => ({
+      key: `s${idx}`,
+      etapaLabel: step.tipoProcesoNombre ?? "Sin etapa",
+      servicioLabel: step.servicioNombre,
+      fechaLabel: formatDateShort(step.firstTs ?? step.asignadoAt),
       media: step.stats.mean,
       stdDev: step.stats.stdDev,
       total: step.stats.totalCount,
     }));
   }, [evolucion]);
 
-  // ── Tab 2: Fetch comparacion ──────────────────────────────────────────────
+  const evoGlobalMean = useMemo(() => {
+    const steps = evolucion.filter((s) => s.stats.totalCount > 0);
+    if (steps.length === 0) return null;
+    const totalCount = steps.reduce((a, s) => a + s.stats.totalCount, 0);
+    const weighted = steps.reduce(
+      (a, s) => a + s.stats.mean * s.stats.totalCount,
+      0
+    );
+    return totalCount > 0 ? weighted / totalCount : null;
+  }, [evolucion]);
+
+  // ── Tab 2: Comparacion fetch ──────────────────────────────────────────────
   useEffect(() => {
     if (selectedLotesComp.length === 0) {
       setComparacion([]);
       return;
     }
     setCompLoading(true);
-    fetch(
-      `/api/analitica/comparacion?loteIds=${selectedLotesComp.join(",")}`
-    )
-      .then((res) => res.json())
+    fetch(`/api/analitica/comparacion?loteIds=${selectedLotesComp.join(",")}`)
+      .then((r) => r.json())
       .then((json) => setComparacion(json.lotes ?? []))
       .catch(console.error)
       .finally(() => setCompLoading(false));
   }, [selectedLotesComp]);
 
-  // Build comparison chart: overlay distributions
   const compChartData = useMemo(() => {
     if (comparacion.length === 0) return [];
     const calibreSet = new Set<number>();
     for (const l of comparacion) {
-      for (const d of l.distribution) calibreSet.add(d.calibre);
+      for (const d of l.distribution) {
+        if (d.calibre != null) calibreSet.add(d.calibre);
+      }
     }
     const calibres = Array.from(calibreSet).sort((a, b) => a - b);
 
     return calibres.map((cal) => {
       const point: Record<string, string | number> = { calibre: cal.toFixed(1) };
-      for (const l of comparacion) {
+      comparacion.forEach((l, idx) => {
         const entry = l.distribution.find((d) => d.calibre === cal);
         const count = entry?.count ?? 0;
-        if (compMode === "porcentaje") {
-          point[l.loteId] =
-            l.stats.totalCount > 0
+        point[`l_${idx}`] =
+          compMode === "porcentaje"
+            ? l.stats.totalCount > 0
               ? parseFloat(((count / l.stats.totalCount) * 100).toFixed(2))
-              : 0;
-        } else {
-          point[l.loteId] = count;
-        }
-      }
+              : 0
+            : count;
+      });
       return point;
     });
   }, [comparacion, compMode]);
 
-  // ── Tab 3: Fetch diff ─────────────────────────────────────────────────────
+  // ── Tab 3: Diferencias fetch ──────────────────────────────────────────────
   useEffect(() => {
     if (!selectedLoteDiff) {
       setDiffEvolucion([]);
@@ -187,19 +236,18 @@ export default function AnaliticaPage() {
     }
     setDiffLoading(true);
     fetch(`/api/analitica/lote-evolucion?loteId=${selectedLoteDiff}`)
-      .then((res) => res.json())
-      .then((data: EvolucionStep[]) => {
-        setDiffEvolucion(data);
-        if (data.length >= 2) {
+      .then((r) => r.json())
+      .then((d: EvolucionStep[]) => {
+        setDiffEvolucion(d);
+        if (d.length >= 2) {
           setDiffStep1(0);
-          setDiffStep2(data.length - 1);
+          setDiffStep2(d.length - 1);
         }
       })
       .catch(console.error)
       .finally(() => setDiffLoading(false));
   }, [selectedLoteDiff]);
 
-  // Build delta chart
   const deltaChartData = useMemo(() => {
     if (
       diffEvolucion.length < 2 ||
@@ -207,27 +255,22 @@ export default function AnaliticaPage() {
       diffStep2 >= diffEvolucion.length
     )
       return [];
-
     const step1 = diffEvolucion[diffStep1];
     const step2 = diffEvolucion[diffStep2];
 
     const calibreSet = new Set<number>();
-    for (const d of step1.distribution) calibreSet.add(d.calibre);
-    for (const d of step2.distribution) calibreSet.add(d.calibre);
-
+    for (const d of step1.distribution) if (d.calibre != null) calibreSet.add(d.calibre);
+    for (const d of step2.distribution) if (d.calibre != null) calibreSet.add(d.calibre);
     const calibres = Array.from(calibreSet).sort((a, b) => a - b);
 
     return calibres.map((cal) => {
-      const count1 =
-        step1.distribution.find((d) => d.calibre === cal)?.count ?? 0;
-      const count2 =
-        step2.distribution.find((d) => d.calibre === cal)?.count ?? 0;
-      const delta = count2 - count1;
+      const count1 = step1.distribution.find((d) => d.calibre === cal)?.count ?? 0;
+      const count2 = step2.distribution.find((d) => d.calibre === cal)?.count ?? 0;
       return {
         calibre: cal.toFixed(1),
-        delta,
-        etapa1: count1,
-        etapa2: count2,
+        etapaA: count1,
+        etapaB: count2,
+        delta: count2 - count1,
       };
     });
   }, [diffEvolucion, diffStep1, diffStep2]);
@@ -235,251 +278,339 @@ export default function AnaliticaPage() {
   if (authLoading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-slate-400 text-sm animate-pulse">Cargando...</div>
+        <div className="text-slate-400 text-sm animate-pulse">Cargando…</div>
       </div>
     );
   }
-
   if (!data) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="text-slate-400 text-sm">No estas autenticado.</div>
+        <div className="text-slate-400 text-sm">No estás autenticado.</div>
       </div>
     );
   }
 
-  // ── Lote selector component ───────────────────────────────────────────────
-  const LoteSelector = ({
-    value,
-    onChange,
-    placeholder,
-  }: {
-    value: string;
-    onChange: (id: string) => void;
-    placeholder?: string;
-  }) => (
-    <div className="relative max-w-sm">
-      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full pl-10 pr-4 py-2 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white focus:outline-none focus:border-cyan-500/40 cursor-pointer"
-      >
-        <option value="">{placeholder ?? "Seleccionar lote..."}</option>
-        {loteOptions.map((l) => (
-          <option key={l.id} value={l.id}>
-            {displayLote(l)}
-            {l.variedadNombre ? ` - ${l.variedadNombre}` : ""}
-          </option>
-        ))}
-      </select>
-    </div>
-  );
+  const selectedEvoLote = payload?.data.find((l) => l.id === selectedLoteEvo);
+  const selectedDiffLote = payload?.data.find((l) => l.id === selectedLoteDiff);
 
   return (
     <div className="w-full max-w-7xl mx-auto p-4 md:p-6 lg:p-8 space-y-6">
       {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight text-white">
-          Analitica
-        </h1>
-        <p className="text-slate-400 mt-1">
-          Evolucion de calibre, comparacion de lotes y metricas estadisticas
-        </p>
+      <div className="flex items-end justify-between flex-wrap gap-3">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-white">
+            Analítica
+          </h1>
+          <p className="text-slate-400 mt-1 text-sm">
+            Evolución de calibre, comparación de lotes y métricas estadísticas
+          </p>
+        </div>
       </div>
 
+      {/* KPIs */}
+      {loadingLotes ? (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-24 rounded-xl bg-slate-900/40 border border-white/5 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : payload ? (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <KpiCard
+            icon={Activity}
+            label="Lotes activos"
+            value={formatNumber(payload.summary.active)}
+            accent="emerald"
+          />
+          <KpiCard
+            icon={Layers}
+            label="Lotes con datos"
+            value={formatNumber(payload.summary.withData)}
+            hint={`de ${formatNumber(payload.total)} totales`}
+            accent="cyan"
+          />
+          <KpiCard
+            icon={Package}
+            label="Total bulbos"
+            value={formatNumber(payload.summary.totalBulbs)}
+            accent="indigo"
+          />
+          <KpiCard
+            icon={Sparkles}
+            label="Última actividad"
+            value={relativeTimeEs(payload.summary.lastActivity)}
+            hint={formatDateShort(payload.summary.lastActivity)}
+            accent="orange"
+          />
+        </div>
+      ) : null}
+
+      {/* Filters */}
+      {payload && (
+        <AnaliticaFilters
+          state={filters}
+          onChange={setFilters}
+          productos={payload.facets.productos}
+          variedades={payload.facets.variedades}
+          etapas={payload.facets.etapas}
+          resultCount={filteredLotes.length}
+          totalCount={payload.total}
+        />
+      )}
+
+      {/* Tabs */}
       <Tabs defaultValue="evolucion" className="space-y-4">
         <TabsList className="bg-slate-800/60 border border-white/10">
           <TabsTrigger
             value="evolucion"
-            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400"
+            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400 gap-1.5"
           >
-            Evolucion
+            <TrendingUp className="w-3.5 h-3.5" />
+            Evolución
           </TabsTrigger>
           <TabsTrigger
             value="comparacion"
-            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400"
+            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400 gap-1.5"
           >
-            Comparacion
+            <BarChart3 className="w-3.5 h-3.5" />
+            Comparación
           </TabsTrigger>
           <TabsTrigger
             value="diferencias"
-            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400"
+            className="data-[state=active]:bg-cyan-500 data-[state=active]:text-slate-950 text-slate-400 gap-1.5"
           >
+            <ArrowLeftRight className="w-3.5 h-3.5" />
             Diferencias
           </TabsTrigger>
         </TabsList>
 
-        {/* ── Tab: Evolucion ───────────────────────────────────────────────── */}
+        {/* ── Tab Evolución ────────────────────────────────────────────────── */}
         <TabsContent value="evolucion" className="space-y-4">
-          <LoteSelector
+          <LoteCombobox
+            options={filteredLotes}
             value={selectedLoteEvo}
             onChange={setSelectedLoteEvo}
-            placeholder="Seleccionar lote para ver evolucion..."
+            placeholder="Seleccionar un lote para ver su evolución…"
           />
+
+          {!selectedLoteEvo && (
+            <EmptyState
+              icon={Search}
+              title="Selecciona un lote"
+              description="Busca por código, variedad o producto. Verás cómo cambia su distribución de calibre etapa por etapa."
+            />
+          )}
 
           {evoLoading && (
             <div className="h-80 rounded-xl bg-slate-900/40 border border-white/5 animate-pulse" />
           )}
 
-          {!evoLoading && evolucion.length > 0 && (
+          {!evoLoading && selectedEvoLote && (
             <>
-              {/* Mean calibre evolution line chart */}
-              <Card className="bg-slate-900/40 border-white/10">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-base text-white">
-                    Evolucion del calibre medio por etapa
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <LineChart
-                      data={evoChartData}
-                      margin={{ top: 10, right: 20, bottom: 5, left: 10 }}
-                    >
-                      <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
-                      <XAxis
-                        dataKey="name"
-                        tick={{ fill: "#64748b", fontSize: 11 }}
-                      />
-                      <YAxis
-                        tick={{ fill: "#64748b", fontSize: 11 }}
-                        domain={["auto", "auto"]}
-                      />
-                      <Tooltip
-                        contentStyle={{
-                          backgroundColor: "#0f172a",
-                          border: "1px solid rgba(255,255,255,0.1)",
-                          borderRadius: "8px",
-                          fontSize: 12,
-                        }}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="media"
-                        stroke="#06b6d4"
-                        strokeWidth={2}
-                        dot={{ r: 5, fill: "#06b6d4" }}
-                        name="Media calibre"
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </CardContent>
-              </Card>
+              <LoteContextCard lote={selectedEvoLote} />
 
-              {/* Stats table */}
-              <Card className="bg-slate-900/40 border-white/10">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-white">
-                    Estadisticas por etapa
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b border-white/10 text-slate-400">
-                          <th className="text-left py-2 pr-4 font-medium">
-                            Etapa
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Total
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Media
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Desv. Est.
-                          </th>
-                          <th className="text-right py-2 font-medium">
-                            Varianza
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-white/5">
-                        {evolucion.map((step) => (
-                          <tr key={step.servicioId} className="text-white">
-                            <td className="py-2.5 pr-4">
-                              <span className="text-cyan-400 text-xs">
-                                {step.tipoProcesoNombre ?? ""}
-                              </span>
-                              <br />
-                              <span className="text-slate-400 text-xs">
-                                {step.servicioNombre}
-                              </span>
-                            </td>
-                            <td className="py-2.5 pr-4 text-right">
-                              {formatNumber(step.stats.totalCount)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-cyan-300">
-                              {step.stats.mean.toFixed(2)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-slate-300">
-                              {step.stats.stdDev.toFixed(2)}
-                            </td>
-                            <td className="py-2.5 text-right font-mono text-slate-400">
-                              {step.stats.variance.toFixed(2)}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </CardContent>
-              </Card>
+              {evolucion.length > 0 ? (
+                <>
+                  <Card className="bg-slate-900/40 border-white/10">
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-base text-white font-semibold tracking-tight">
+                        Evolución del calibre medio
+                      </CardTitle>
+                      <p className="text-xs text-slate-500">
+                        Cada punto representa una asignación a un servicio
+                        {evoGlobalMean != null && (
+                          <>
+                            {" "}· media global del lote{" "}
+                            <span className="font-mono text-cyan-300">
+                              {evoGlobalMean.toFixed(2)}
+                            </span>
+                          </>
+                        )}
+                      </p>
+                    </CardHeader>
+                    <CardContent>
+                      <ResponsiveContainer width="100%" height={320}>
+                        <LineChart
+                          data={evoChartData}
+                          margin={{ top: 10, right: 20, bottom: 30, left: 10 }}
+                        >
+                          <defs>
+                            <linearGradient id="evoLineGradient" x1="0" y1="0" x2="1" y2="0">
+                              <stop offset="0%" stopColor="#06b6d4" />
+                              <stop offset="100%" stopColor="#6366f1" />
+                            </linearGradient>
+                          </defs>
+                          <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                          <XAxis
+                            dataKey="key"
+                            tick={<EtapaTick data={evoChartData} />}
+                            interval={0}
+                            height={56}
+                            stroke="#334155"
+                          />
+                          <YAxis
+                            tick={{ fill: "#64748b", fontSize: 11 }}
+                            domain={["auto", "auto"]}
+                          />
+                          <Tooltip
+                            content={<EvoTooltip />}
+                            cursor={{ stroke: "#334155", strokeWidth: 1 }}
+                          />
+                          {evoGlobalMean != null && (
+                            <ReferenceLine
+                              y={evoGlobalMean}
+                              stroke="#f59e0b"
+                              strokeDasharray="4 4"
+                              strokeOpacity={0.6}
+                              label={{
+                                value: "Media global",
+                                position: "insideTopRight",
+                                fill: "#f59e0b",
+                                fontSize: 10,
+                              }}
+                            />
+                          )}
+                          <Line
+                            type="monotone"
+                            dataKey="media"
+                            stroke="url(#evoLineGradient)"
+                            strokeWidth={2.5}
+                            dot={{ r: 5, fill: "#06b6d4", stroke: "#0f172a", strokeWidth: 2 }}
+                            activeDot={{ r: 7 }}
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </CardContent>
+                  </Card>
+
+                  <Card className="bg-slate-900/40 border-white/10">
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm text-white font-semibold">
+                        Estadísticas por etapa
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="border-b border-white/10 text-[10px] uppercase tracking-wide text-slate-500">
+                              <th className="text-left py-2 pr-4 font-medium">Etapa · Servicio</th>
+                              <th className="text-left py-2 pr-4 font-medium">Fecha</th>
+                              <th className="text-right py-2 pr-4 font-medium">Total</th>
+                              <th className="text-right py-2 pr-4 font-medium">Media</th>
+                              <th className="text-right py-2 pr-4 font-medium">σ</th>
+                              <th className="text-right py-2 font-medium">Rango</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-white/5">
+                            {evolucion.map((step, idx) => (
+                              <tr
+                                key={`${step.servicioId}-${idx}`}
+                                className="text-white hover:bg-white/[0.02] transition-colors"
+                              >
+                                <td className="py-2.5 pr-4">
+                                  <div className="text-white text-sm font-medium">
+                                    {step.tipoProcesoNombre ?? "Sin etapa"}
+                                  </div>
+                                  <div className="text-slate-500 text-xs">
+                                    {step.servicioNombre}
+                                    {step.procesoTemporada && (
+                                      <span className="text-slate-600"> · {step.procesoTemporada}</span>
+                                    )}
+                                  </div>
+                                </td>
+                                <td className="py-2.5 pr-4 text-slate-400 text-xs whitespace-nowrap">
+                                  {formatDateShort(step.firstTs ?? step.asignadoAt)}
+                                </td>
+                                <td className="py-2.5 pr-4 text-right font-mono">
+                                  {formatNumber(step.stats.totalCount)}
+                                </td>
+                                <td className="py-2.5 pr-4 text-right font-mono text-cyan-300">
+                                  {step.stats.mean.toFixed(2)}
+                                </td>
+                                <td className="py-2.5 pr-4 text-right font-mono text-slate-300">
+                                  {step.stats.stdDev.toFixed(2)}
+                                </td>
+                                <td className="py-2.5 text-right font-mono text-slate-400 text-xs">
+                                  {step.stats.min.toFixed(1)} – {step.stats.max.toFixed(1)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </>
+              ) : (
+                <EmptyState
+                  icon={Layers}
+                  title="Este lote aún no tiene mediciones"
+                  description="No se registran datos de calibre en ninguna etapa para este lote."
+                />
+              )}
             </>
-          )}
-
-          {!evoLoading && selectedLoteEvo && evolucion.length === 0 && (
-            <div className="text-center py-12 text-slate-500 text-sm">
-              No hay datos de evolucion para este lote.
-            </div>
           )}
         </TabsContent>
 
-        {/* ── Tab: Comparacion ─────────────────────────────────────────────── */}
+        {/* ── Tab Comparación ──────────────────────────────────────────────── */}
         <TabsContent value="comparacion" className="space-y-4">
-          {/* Multi-select lotes */}
           <div className="space-y-3">
-            <div className="flex flex-wrap gap-2">
-              {selectedLotesComp.map((id) => (
-                <Badge
-                  key={id}
-                  className="bg-cyan-500/20 text-cyan-300 border-cyan-500/40 cursor-pointer hover:bg-red-500/20 hover:text-red-300 hover:border-red-500/40 transition-colors"
-                  onClick={() =>
-                    setSelectedLotesComp((prev) =>
-                      prev.filter((l) => l !== id)
-                    )
+            {selectedLotesComp.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {selectedLotesComp.map((id, idx) => {
+                  const lote = payload?.data.find((l) => l.id === id);
+                  if (!lote) return null;
+                  return (
+                    <Badge
+                      key={id}
+                      className="bg-slate-900/60 text-white border-white/10 hover:bg-red-500/15 hover:text-red-300 hover:border-red-500/30 cursor-pointer transition-colors gap-1.5"
+                      onClick={() =>
+                        setSelectedLotesComp((prev) => prev.filter((l) => l !== id))
+                      }
+                    >
+                      <span
+                        className="inline-block w-2 h-2 rounded-full"
+                        style={{ backgroundColor: COLORS[idx % COLORS.length] }}
+                      />
+                      <span className="font-mono">{displayLoteCode(lote)}</span>
+                      {lote.variedadNombre && (
+                        <span className="text-slate-400 text-xs">
+                          · {lote.variedadNombre}
+                        </span>
+                      )}
+                      <X className="w-3 h-3 ml-0.5" />
+                    </Badge>
+                  );
+                })}
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 flex-wrap">
+              <div className="flex-1 min-w-[260px] max-w-md">
+                <LoteCombobox
+                  options={filteredLotes}
+                  value=""
+                  onChange={(id) => {
+                    if (id && selectedLotesComp.length < 5) {
+                      setSelectedLotesComp((prev) => [...prev, id]);
+                    }
+                  }}
+                  placeholder={
+                    selectedLotesComp.length >= 5
+                      ? "Máximo 5 lotes"
+                      : "Agregar lote a comparar…"
                   }
-                >
-                  {displayLote(loteOptions.find((l) => l.id === id) ?? {})} <X className="w-3 h-3 ml-1" />
-                </Badge>
-              ))}
-            </div>
-            <div className="max-w-sm">
-              <select
-                value=""
-                onChange={(e) => {
-                  if (
-                    e.target.value &&
-                    !selectedLotesComp.includes(e.target.value) &&
-                    selectedLotesComp.length < 5
-                  ) {
-                    setSelectedLotesComp((prev) => [...prev, e.target.value]);
-                  }
-                }}
-                className="w-full px-3 py-2 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white focus:outline-none focus:border-cyan-500/40 cursor-pointer"
-              >
-                <option value="">Agregar lote para comparar...</option>
-                {loteOptions
-                  .filter((l) => !selectedLotesComp.includes(l.id))
-                  .map((l) => (
-                    <option key={l.id} value={l.id}>
-                      {displayLote(l)}
-                      {l.variedadNombre ? ` - ${l.variedadNombre}` : ""}
-                    </option>
-                  ))}
-              </select>
+                  excludeIds={selectedLotesComp}
+                />
+              </div>
+              <span className="text-xs text-slate-500 flex items-center gap-1">
+                <Plus className="w-3 h-3" />
+                {selectedLotesComp.length}/5 lotes
+              </span>
             </div>
           </div>
 
@@ -487,15 +618,27 @@ export default function AnaliticaPage() {
             <div className="h-80 rounded-xl bg-slate-900/40 border border-white/5 animate-pulse" />
           )}
 
+          {!compLoading && selectedLotesComp.length === 0 && (
+            <EmptyState
+              icon={BarChart3}
+              title="Compara hasta 5 lotes"
+              description="Agrega lotes para comparar sus distribuciones de calibre lado a lado."
+            />
+          )}
+
           {!compLoading && comparacion.length > 0 && (
             <>
-              {/* Overlay distribution chart */}
               <Card className="bg-slate-900/40 border-white/10">
                 <CardHeader className="pb-2">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-base text-white">
-                      Distribucion de calibre
-                    </CardTitle>
+                  <div className="flex items-center justify-between gap-3 flex-wrap">
+                    <div>
+                      <CardTitle className="text-base text-white font-semibold tracking-tight">
+                        Distribución de calibre
+                      </CardTitle>
+                      <p className="text-xs text-slate-500 mt-0.5">
+                        Cantidad de bulbos por calibre, agregada por todas las etapas de cada lote.
+                      </p>
+                    </div>
                     <div className="flex gap-1">
                       {(["cantidad", "porcentaje"] as const).map((mode) => (
                         <button
@@ -519,42 +662,75 @@ export default function AnaliticaPage() {
                       data={compChartData}
                       margin={{ top: 10, right: 10, bottom: 20, left: 10 }}
                     >
+                      <defs>
+                        {comparacion.map((_, idx) => (
+                          <linearGradient
+                            key={idx}
+                            id={`compGrad-${idx}`}
+                            x1="0"
+                            y1="0"
+                            x2="0"
+                            y2="1"
+                          >
+                            <stop
+                              offset="0%"
+                              stopColor={COLORS[idx % COLORS.length]}
+                              stopOpacity={0.95}
+                            />
+                            <stop
+                              offset="100%"
+                              stopColor={COLORS[idx % COLORS.length]}
+                              stopOpacity={0.55}
+                            />
+                          </linearGradient>
+                        ))}
+                      </defs>
                       <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
                       <XAxis
                         dataKey="calibre"
                         tick={{ fill: "#64748b", fontSize: 10 }}
+                        label={{
+                          value: "Calibre",
+                          position: "insideBottom",
+                          offset: -10,
+                          fill: "#475569",
+                          fontSize: 10,
+                        }}
                       />
                       <YAxis
                         tick={{ fill: "#64748b", fontSize: 10 }}
                         tickFormatter={(v) =>
-                          compMode === "porcentaje"
-                            ? `${v}%`
-                            : v.toLocaleString("es-CL")
+                          compMode === "porcentaje" ? `${v}%` : v.toLocaleString("es-CL")
                         }
                       />
                       <Tooltip
                         contentStyle={{
-                          backgroundColor: "#0f172a",
+                          backgroundColor: "rgba(15,23,42,0.95)",
                           border: "1px solid rgba(255,255,255,0.1)",
                           borderRadius: "8px",
                           fontSize: 12,
                         }}
+                        labelStyle={{ color: "#94a3b8" }}
+                        itemStyle={{ color: "#e2e8f0" }}
                         formatter={(value: number, name: string) => [
                           compMode === "porcentaje"
                             ? `${value.toFixed(2)}%`
                             : formatNumber(value),
                           name,
                         ]}
+                        labelFormatter={(label) => `Calibre ${label}`}
                       />
-                      <Legend />
+                      <Legend
+                        wrapperStyle={{ paddingTop: 8, fontSize: 12 }}
+                        iconType="circle"
+                      />
                       {comparacion.map((l, idx) => (
                         <Bar
                           key={l.loteId}
-                          dataKey={l.loteId}
-                          name={displayLote(l)}
-                          fill={COLORS[idx % COLORS.length]}
-                          fillOpacity={0.7}
-                          radius={[2, 2, 0, 0]}
+                          dataKey={`l_${idx}`}
+                          name={displayLoteCode(l)}
+                          fill={`url(#compGrad-${idx})`}
+                          radius={[3, 3, 0, 0]}
                         />
                       ))}
                     </BarChart>
@@ -562,72 +738,69 @@ export default function AnaliticaPage() {
                 </CardContent>
               </Card>
 
-              {/* Stats comparison table */}
               <Card className="bg-slate-900/40 border-white/10">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-white">
-                    Metricas estadisticas
+                  <CardTitle className="text-sm text-white font-semibold">
+                    Métricas estadísticas
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
                   <div className="overflow-x-auto">
                     <table className="w-full text-sm">
                       <thead>
-                        <tr className="border-b border-white/10 text-slate-400">
-                          <th className="text-left py-2 pr-4 font-medium">
-                            Lote
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Total
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Media
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Desv. Est.
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Varianza
-                          </th>
-                          <th className="text-right py-2 pr-4 font-medium">
-                            Min
-                          </th>
-                          <th className="text-right py-2 font-medium">Max</th>
+                        <tr className="border-b border-white/10 text-[10px] uppercase tracking-wide text-slate-500">
+                          <th className="text-left py-2 pr-4 font-medium">Lote</th>
+                          <th className="text-right py-2 pr-4 font-medium">Total</th>
+                          <th className="text-right py-2 pr-4 font-medium">Media</th>
+                          <th className="text-right py-2 pr-4 font-medium">σ</th>
+                          <th className="text-right py-2 pr-4 font-medium">Varianza</th>
+                          <th className="text-right py-2 font-medium">Rango</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-white/5">
-                        {comparacion.map((l, idx) => (
-                          <tr key={l.loteId} className="text-white">
-                            <td className="py-2.5 pr-4 font-mono text-xs">
-                              <span
-                                className="inline-block w-2 h-2 rounded-full mr-2"
-                                style={{
-                                  backgroundColor:
-                                    COLORS[idx % COLORS.length],
-                                }}
-                              />
-                              {displayLote(l)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right">
-                              {formatNumber(l.stats.totalCount)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-cyan-300">
-                              {l.stats.mean.toFixed(2)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-slate-300">
-                              {l.stats.stdDev.toFixed(2)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-slate-400">
-                              {l.stats.variance.toFixed(2)}
-                            </td>
-                            <td className="py-2.5 pr-4 text-right font-mono text-slate-400">
-                              {l.stats.min.toFixed(1)}
-                            </td>
-                            <td className="py-2.5 text-right font-mono text-slate-400">
-                              {l.stats.max.toFixed(1)}
-                            </td>
-                          </tr>
-                        ))}
+                        {comparacion.map((l, idx) => {
+                          const fullLote = payload?.data.find((x) => x.id === l.loteId);
+                          return (
+                            <tr
+                              key={l.loteId}
+                              className="text-white hover:bg-white/[0.02] transition-colors"
+                            >
+                              <td className="py-2.5 pr-4">
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className="inline-block w-2 h-2 rounded-full shrink-0"
+                                    style={{
+                                      backgroundColor: COLORS[idx % COLORS.length],
+                                    }}
+                                  />
+                                  <span className="font-mono text-sm">
+                                    {displayLoteCode(l)}
+                                  </span>
+                                  {fullLote?.variedadNombre && (
+                                    <span className="text-slate-500 text-xs">
+                                      · {fullLote.variedadNombre}
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td className="py-2.5 pr-4 text-right font-mono">
+                                {formatNumber(l.stats.totalCount)}
+                              </td>
+                              <td className="py-2.5 pr-4 text-right font-mono text-cyan-300">
+                                {l.stats.mean.toFixed(2)}
+                              </td>
+                              <td className="py-2.5 pr-4 text-right font-mono text-slate-300">
+                                {l.stats.stdDev.toFixed(2)}
+                              </td>
+                              <td className="py-2.5 pr-4 text-right font-mono text-slate-400">
+                                {l.stats.variance.toFixed(2)}
+                              </td>
+                              <td className="py-2.5 text-right font-mono text-slate-400 text-xs">
+                                {l.stats.min.toFixed(1)} – {l.stats.max.toFixed(1)}
+                              </td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </table>
                   </div>
@@ -637,116 +810,151 @@ export default function AnaliticaPage() {
           )}
         </TabsContent>
 
-        {/* ── Tab: Diferencias ─────────────────────────────────────────────── */}
+        {/* ── Tab Diferencias ──────────────────────────────────────────────── */}
         <TabsContent value="diferencias" className="space-y-4">
-          <LoteSelector
+          <LoteCombobox
+            options={filteredLotes}
             value={selectedLoteDiff}
             onChange={setSelectedLoteDiff}
-            placeholder="Seleccionar lote para ver diferencias..."
+            placeholder="Seleccionar lote para comparar etapas…"
           />
+
+          {!selectedLoteDiff && (
+            <EmptyState
+              icon={ArrowLeftRight}
+              title="Selecciona un lote"
+              description="Verás la diferencia de calibre entre dos etapas cualesquiera de su trayectoria."
+            />
+          )}
 
           {diffLoading && (
             <div className="h-80 rounded-xl bg-slate-900/40 border border-white/5 animate-pulse" />
           )}
 
-          {!diffLoading && diffEvolucion.length >= 2 && (
+          {!diffLoading && selectedDiffLote && diffEvolucion.length >= 2 && (
             <>
-              {/* Step selectors */}
-              <div className="flex flex-wrap gap-4">
-                <div>
-                  <label className="text-xs text-slate-500 block mb-1">
-                    Etapa A
-                  </label>
-                  <select
-                    value={diffStep1}
-                    onChange={(e) => setDiffStep1(Number(e.target.value))}
-                    className="px-3 py-1.5 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white focus:outline-none focus:border-cyan-500/40 cursor-pointer"
-                  >
-                    {diffEvolucion.map((step, idx) => (
-                      <option key={idx} value={idx}>
-                        {step.tipoProcesoNombre ?? step.servicioNombre}
-                      </option>
-                    ))}
-                  </select>
+              <LoteContextCard lote={selectedDiffLote} />
+
+              <div className="flex flex-wrap gap-4 items-end">
+                <StepSelect
+                  label="Etapa A"
+                  value={diffStep1}
+                  steps={diffEvolucion}
+                  onChange={setDiffStep1}
+                  accent="cyan"
+                />
+                <div className="pb-1.5 text-slate-500 text-sm flex items-center gap-1">
+                  <ArrowLeftRight className="w-3.5 h-3.5" />
+                  vs
                 </div>
-                <div className="flex items-end pb-1 text-slate-500">vs</div>
-                <div>
-                  <label className="text-xs text-slate-500 block mb-1">
-                    Etapa B
-                  </label>
-                  <select
-                    value={diffStep2}
-                    onChange={(e) => setDiffStep2(Number(e.target.value))}
-                    className="px-3 py-1.5 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white focus:outline-none focus:border-cyan-500/40 cursor-pointer"
-                  >
-                    {diffEvolucion.map((step, idx) => (
-                      <option key={idx} value={idx}>
-                        {step.tipoProcesoNombre ?? step.servicioNombre}
-                      </option>
-                    ))}
-                  </select>
-                </div>
+                <StepSelect
+                  label="Etapa B"
+                  value={diffStep2}
+                  steps={diffEvolucion}
+                  onChange={setDiffStep2}
+                  accent="emerald"
+                />
               </div>
 
-              {/* Delta chart */}
               <Card className="bg-slate-900/40 border-white/10">
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-base text-white">
-                    Diferencia por calibre
-                    <span className="text-sm font-normal text-slate-400 ml-2">
-                      (
-                      {diffEvolucion[diffStep2]?.tipoProcesoNombre ??
-                        diffEvolucion[diffStep2]?.servicioNombre}{" "}
-                      vs{" "}
-                      {diffEvolucion[diffStep1]?.tipoProcesoNombre ??
-                        diffEvolucion[diffStep1]?.servicioNombre}
-                      )
-                    </span>
+                  <CardTitle className="text-base text-white font-semibold tracking-tight">
+                    Distribución comparada
                   </CardTitle>
+                  <p className="text-xs text-slate-500 mt-0.5">
+                    Etapa A en cyan, etapa B en emerald — por calibre.
+                  </p>
+                </CardHeader>
+                <CardContent>
+                  <ResponsiveContainer width="100%" height={260}>
+                    <BarChart
+                      data={deltaChartData}
+                      margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                      <XAxis dataKey="calibre" tick={{ fill: "#64748b", fontSize: 10 }} />
+                      <YAxis
+                        tick={{ fill: "#64748b", fontSize: 10 }}
+                        tickFormatter={(v) => v.toLocaleString("es-CL")}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: "rgba(15,23,42,0.95)",
+                          border: "1px solid rgba(255,255,255,0.1)",
+                          borderRadius: "8px",
+                          fontSize: 12,
+                        }}
+                        labelStyle={{ color: "#94a3b8" }}
+                        itemStyle={{ color: "#e2e8f0" }}
+                        labelFormatter={(label) => `Calibre ${label}`}
+                        formatter={(value: number, name: string) => [
+                          formatNumber(value),
+                          name === "etapaA"
+                            ? diffEvolucion[diffStep1]?.tipoProcesoNombre ?? "Etapa A"
+                            : diffEvolucion[diffStep2]?.tipoProcesoNombre ?? "Etapa B",
+                        ]}
+                      />
+                      <Legend wrapperStyle={{ paddingTop: 6, fontSize: 11 }} iconType="circle" />
+                      <Bar
+                        dataKey="etapaA"
+                        name={diffEvolucion[diffStep1]?.tipoProcesoNombre ?? "Etapa A"}
+                        fill="#06b6d4"
+                        radius={[3, 3, 0, 0]}
+                      />
+                      <Bar
+                        dataKey="etapaB"
+                        name={diffEvolucion[diffStep2]?.tipoProcesoNombre ?? "Etapa B"}
+                        fill="#10b981"
+                        radius={[3, 3, 0, 0]}
+                      />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </CardContent>
+              </Card>
+
+              <Card className="bg-slate-900/40 border-white/10">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base text-white font-semibold tracking-tight">
+                    Δ Diferencia (B − A)
+                  </CardTitle>
+                  <p className="text-xs text-slate-500 mt-0.5">
+                    Verde = ganancia de bulbos en ese calibre. Rojo = pérdida.
+                  </p>
                 </CardHeader>
                 <CardContent>
                   {deltaChartData.length === 0 ? (
-                    <div className="h-[300px] flex items-center justify-center text-slate-500 text-sm">
+                    <div className="h-[200px] flex items-center justify-center text-slate-500 text-sm">
                       Sin datos para comparar
                     </div>
                   ) : (
-                    <ResponsiveContainer width="100%" height={300}>
+                    <ResponsiveContainer width="100%" height={220}>
                       <BarChart
                         data={deltaChartData}
-                        margin={{ top: 10, right: 10, bottom: 20, left: 10 }}
+                        margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
                       >
-                        <CartesianGrid
-                          strokeDasharray="3 3"
-                          stroke="#1e293b"
-                        />
-                        <XAxis
-                          dataKey="calibre"
-                          tick={{ fill: "#64748b", fontSize: 10 }}
-                        />
+                        <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                        <XAxis dataKey="calibre" tick={{ fill: "#64748b", fontSize: 10 }} />
                         <YAxis
                           tick={{ fill: "#64748b", fontSize: 10 }}
                           tickFormatter={(v) => v.toLocaleString("es-CL")}
                         />
+                        <ReferenceLine y={0} stroke="#475569" />
                         <Tooltip
                           contentStyle={{
-                            backgroundColor: "#0f172a",
+                            backgroundColor: "rgba(15,23,42,0.95)",
                             border: "1px solid rgba(255,255,255,0.1)",
                             borderRadius: "8px",
                             fontSize: 12,
                           }}
-                          formatter={(value: number, name: string) => [
-                            formatNumber(value),
-                            name === "delta" ? "Diferencia" : name,
-                          ]}
+                          labelStyle={{ color: "#94a3b8" }}
+                          itemStyle={{ color: "#e2e8f0" }}
+                          formatter={(value: number) => [formatNumber(value), "Δ bulbos"]}
+                          labelFormatter={(label) => `Calibre ${label}`}
                         />
-                        <Bar
-                          dataKey="delta"
-                          fill="#06b6d4"
-                          radius={[4, 4, 0, 0]}
-                        >
-                          {deltaChartData.map((entry, idx) => (
-                            <rect
-                              key={idx}
+                        <Bar dataKey="delta" radius={[3, 3, 0, 0]}>
+                          {deltaChartData.map((entry) => (
+                            <Cell
+                              key={entry.calibre}
                               fill={entry.delta >= 0 ? "#10b981" : "#ef4444"}
                             />
                           ))}
@@ -757,105 +965,206 @@ export default function AnaliticaPage() {
                 </CardContent>
               </Card>
 
-              {/* Summary stats comparison */}
-              {diffEvolucion[diffStep1] && diffEvolucion[diffStep2] && (
-                <Card className="bg-slate-900/40 border-white/10">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-sm text-white">
-                      Comparacion de estadisticas
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="overflow-x-auto">
-                      <table className="w-full text-sm">
-                        <thead>
-                          <tr className="border-b border-white/10 text-slate-400">
-                            <th className="text-left py-2 pr-4 font-medium">
-                              Metrica
-                            </th>
-                            <th className="text-right py-2 pr-4 font-medium">
-                              {diffEvolucion[diffStep1].tipoProcesoNombre ??
-                                "Etapa A"}
-                            </th>
-                            <th className="text-right py-2 pr-4 font-medium">
-                              {diffEvolucion[diffStep2].tipoProcesoNombre ??
-                                "Etapa B"}
-                            </th>
-                            <th className="text-right py-2 font-medium">
-                              Delta
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody className="divide-y divide-white/5">
-                          {[
-                            {
-                              label: "Total bulbos",
-                              a: diffEvolucion[diffStep1].stats.totalCount,
-                              b: diffEvolucion[diffStep2].stats.totalCount,
-                              format: formatNumber,
-                            },
-                            {
-                              label: "Media calibre",
-                              a: diffEvolucion[diffStep1].stats.mean,
-                              b: diffEvolucion[diffStep2].stats.mean,
-                              format: (v: number) => v.toFixed(2),
-                            },
-                            {
-                              label: "Desv. estandar",
-                              a: diffEvolucion[diffStep1].stats.stdDev,
-                              b: diffEvolucion[diffStep2].stats.stdDev,
-                              format: (v: number) => v.toFixed(2),
-                            },
-                          ].map((row) => {
-                            const delta = row.b - row.a;
-                            const pct =
-                              row.a !== 0
-                                ? ((delta / row.a) * 100).toFixed(1)
-                                : "\u2014";
-                            return (
-                              <tr key={row.label} className="text-white">
-                                <td className="py-2.5 pr-4 text-slate-400">
-                                  {row.label}
-                                </td>
-                                <td className="py-2.5 pr-4 text-right font-mono">
-                                  {row.format(row.a)}
-                                </td>
-                                <td className="py-2.5 pr-4 text-right font-mono">
-                                  {row.format(row.b)}
-                                </td>
-                                <td
-                                  className={`py-2.5 text-right font-mono ${
-                                    delta > 0
-                                      ? "text-emerald-400"
-                                      : delta < 0
-                                      ? "text-red-400"
-                                      : "text-slate-400"
-                                  }`}
-                                >
-                                  {delta > 0 ? "+" : ""}
-                                  {row.format(delta)} ({pct}%)
-                                </td>
-                              </tr>
-                            );
-                          })}
-                        </tbody>
-                      </table>
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+              <Card className="bg-slate-900/40 border-white/10">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm text-white font-semibold">
+                    Resumen
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-white/10 text-[10px] uppercase tracking-wide text-slate-500">
+                          <th className="text-left py-2 pr-4 font-medium">Métrica</th>
+                          <th className="text-right py-2 pr-4 font-medium">
+                            {diffEvolucion[diffStep1].tipoProcesoNombre ?? "Etapa A"}
+                          </th>
+                          <th className="text-right py-2 pr-4 font-medium">
+                            {diffEvolucion[diffStep2].tipoProcesoNombre ?? "Etapa B"}
+                          </th>
+                          <th className="text-right py-2 font-medium">Δ</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-white/5">
+                        {[
+                          {
+                            label: "Total bulbos",
+                            a: diffEvolucion[diffStep1].stats.totalCount,
+                            b: diffEvolucion[diffStep2].stats.totalCount,
+                            format: formatNumber,
+                          },
+                          {
+                            label: "Media calibre",
+                            a: diffEvolucion[diffStep1].stats.mean,
+                            b: diffEvolucion[diffStep2].stats.mean,
+                            format: (v: number) => v.toFixed(2),
+                          },
+                          {
+                            label: "Desv. estándar",
+                            a: diffEvolucion[diffStep1].stats.stdDev,
+                            b: diffEvolucion[diffStep2].stats.stdDev,
+                            format: (v: number) => v.toFixed(2),
+                          },
+                        ].map((row) => {
+                          const delta = row.b - row.a;
+                          const pct = row.a !== 0 ? ((delta / row.a) * 100).toFixed(1) : "—";
+                          return (
+                            <tr
+                              key={row.label}
+                              className="text-white hover:bg-white/[0.02] transition-colors"
+                            >
+                              <td className="py-2.5 pr-4 text-slate-400">{row.label}</td>
+                              <td className="py-2.5 pr-4 text-right font-mono">{row.format(row.a)}</td>
+                              <td className="py-2.5 pr-4 text-right font-mono">{row.format(row.b)}</td>
+                              <td
+                                className={`py-2.5 text-right font-mono ${
+                                  delta > 0
+                                    ? "text-emerald-400"
+                                    : delta < 0
+                                    ? "text-red-400"
+                                    : "text-slate-400"
+                                }`}
+                              >
+                                {delta > 0 ? "+" : ""}
+                                {row.format(delta)}
+                                {pct !== "—" && (
+                                  <span className="text-slate-500 ml-1">({pct}%)</span>
+                                )}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </CardContent>
+              </Card>
             </>
           )}
 
-          {!diffLoading &&
-            selectedLoteDiff &&
-            diffEvolucion.length < 2 && (
-              <div className="text-center py-12 text-slate-500 text-sm">
-                Este lote necesita al menos 2 etapas para comparar diferencias.
-              </div>
-            )}
+          {!diffLoading && selectedDiffLote && diffEvolucion.length < 2 && (
+            <EmptyState
+              icon={ArrowLeftRight}
+              title="No hay suficientes etapas"
+              description="Este lote necesita al menos 2 etapas con datos para comparar diferencias."
+            />
+          )}
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+// ── Helpers / subcomponents ─────────────────────────────────────────────────
+
+function StepSelect({
+  label,
+  value,
+  steps,
+  onChange,
+  accent,
+}: {
+  label: string;
+  value: number;
+  steps: EvolucionStep[];
+  onChange: (n: number) => void;
+  accent: "cyan" | "emerald";
+}) {
+  const accentColor = accent === "cyan" ? "border-cyan-500/40" : "border-emerald-500/40";
+  return (
+    <div>
+      <label className="text-[10px] uppercase tracking-wide text-slate-500 block mb-1">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className={`px-3 py-1.5 rounded-lg bg-slate-900/40 border border-white/10 text-sm text-white focus:outline-none focus:${accentColor} cursor-pointer min-w-[220px]`}
+      >
+        {steps.map((step, idx) => (
+          <option key={idx} value={idx}>
+            {step.tipoProcesoNombre ?? "Sin etapa"} · {step.servicioNombre} ·{" "}
+            {formatDateShort(step.firstTs ?? step.asignadoAt)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+interface EtapaChartPoint {
+  key: string;
+  etapaLabel: string;
+  servicioLabel: string;
+  fechaLabel: string;
+  media: number;
+  stdDev: number;
+  total: number;
+}
+
+function EtapaTick({
+  data,
+  x,
+  y,
+  payload,
+}: {
+  data: EtapaChartPoint[];
+  x?: number;
+  y?: number;
+  payload?: { value: string };
+}) {
+  const point = data.find((d) => d.key === payload?.value);
+  if (!point || x == null || y == null) return null;
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={0}
+        dy={14}
+        textAnchor="middle"
+        fill="#cbd5e1"
+        fontSize={11}
+        fontWeight={500}
+      >
+        {point.etapaLabel}
+      </text>
+      <text x={0} y={0} dy={28} textAnchor="middle" fill="#64748b" fontSize={9}>
+        {point.servicioLabel}
+      </text>
+      <text x={0} y={0} dy={42} textAnchor="middle" fill="#475569" fontSize={9}>
+        {point.fechaLabel}
+      </text>
+    </g>
+  );
+}
+
+function EvoTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload: EtapaChartPoint }[];
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const p = payload[0].payload;
+  return (
+    <div className="rounded-lg bg-slate-950/95 border border-white/10 shadow-xl px-3 py-2 text-xs">
+      <div className="font-semibold text-white">{p.etapaLabel}</div>
+      <div className="text-slate-400">{p.servicioLabel}</div>
+      <div className="text-slate-500 text-[10px] mb-1.5">{p.fechaLabel}</div>
+      <div className="flex justify-between gap-4 text-slate-300">
+        <span>Media</span>
+        <span className="font-mono text-cyan-300">{p.media.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between gap-4 text-slate-300">
+        <span>σ</span>
+        <span className="font-mono">{p.stdDev.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between gap-4 text-slate-300">
+        <span>Total</span>
+        <span className="font-mono">{formatNumber(p.total)}</span>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Resumen

- **Combobox de búsqueda** reemplaza el `<select>` nativo — busca por código, variedad y producto. Cada opción muestra etapa actual, servicio, total de bulbos y última actividad. Lotes sin datos aparecen atenuados al final con badge "Sin datos".
- **Barra de filtros contextuales** (variedad, etapa, actividad, toggle "Ocultar sin datos") que acota el universo de lotes antes de elegir uno.
- **KPIs de cabecera** (lotes activos, lotes con datos, total bulbos, última actividad).
- **Tarjeta de contexto del lote** visible en las 3 tabs — código, variedad/producto, etapa, bulbos, timestamps — para que el usuario no pierda de vista qué lote está analizando.
- **Evolución**: eje X con tick de 3 líneas (etapa / servicio / fecha), tooltip rico con media/σ/total, línea de referencia de media global, gradiente en la línea.
- **Comparación**: corrige bug donde la leyenda y el `dataKey` mostraban UUIDs en lugar de códigos de lote.
- **Diferencias**: añade chart de barras lado-a-lado (etapa A vs B) además del chart de delta con `Cell` verde/rojo y `ReferenceLine` en 0.
- **Empty states** ilustrados con icono + descripción contextual para cada tab.
- **API `lote-evolucion`** extendida con `firstTs`, `lastTs`, `procesoTemporada`, `min/max` por etapa.
- Tipografía consistente, `font-mono` en números, `uppercase tracking-wide` en headers de tabla.

## Plan de pruebas

- [ ] Abrir `/app/analitica` — KPIs cargados, filtros visibles
- [ ] Abrir combobox — buscar por código, variedad, producto; verificar línea 2 con etapa/bulbos/actividad; lotes sin datos al final atenuados
- [ ] Filtro por variedad → reduce opciones del combobox; toggle "sin datos" los oculta
- [ ] Tab Evolución: seleccionar lote con etapas → eje X muestra etapa·servicio·fecha; tooltip; `LoteContextCard` visible
- [ ] Tab Comparación: añadir 3 lotes → leyenda muestra códigos; Cantidad/Porcentaje; quitar chip
- [ ] Tab Diferencias: seleccionar lote con ≥2 etapas → chart side-by-side + delta coloreado; tabla resumen con Δ
- [ ] Verificar `/app/control` y `/app/lote/[id]` no regresionan

🤖 Generated with [Claude Code](https://claude.com/claude-code)