### PR TITLE
feat: agregar vista de produccion por hora desglosada por dispositivo

### DIFF
--- a/my-project/src/app/api/control/produccion/route.ts
+++ b/my-project/src/app/api/control/produccion/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { conteo, servicio } from "@/db/schema";
+import { conteo, servicio, dispositivo } from "@/db/schema";
 import { eq, and, gte, lte, inArray, sql } from "drizzle-orm";
 
 export async function GET(request: Request) {
@@ -39,6 +39,8 @@ export async function GET(request: Request) {
   if (servicioIds.length === 0) {
     return NextResponse.json({
       hourly: [],
+      hourlyPorDispositivo: [],
+      dispositivos: [],
       daily: [],
       total: 0,
       avgPerHour: 0,
@@ -47,8 +49,11 @@ export async function GET(request: Request) {
     });
   }
 
-  // Una sola consulta agrupada por (date, hour). De aquí derivamos en JS:
-  // hourly, daily, total y jornada (inicio/fin), evitando 4 escaneos de la tabla.
+  // Una sola consulta agrupada por (date, hour, dispositivo). De aquí derivamos
+  // en JS: hourlyPorDispositivo, hourly, daily, total y jornada (inicio/fin),
+  // evitando escanear la tabla más de una vez. El dispositivo entra en el group
+  // by porque es la granularidad más fina que necesitamos: todo lo demás sale
+  // de sumar sobre estas filas.
   const localTs = sql`${conteo.ts} AT TIME ZONE 'America/Santiago'`;
   const dateExpr = sql<string>`TO_CHAR(${localTs}, 'YYYY-MM-DD')`;
   const hourExpr = sql<number>`EXTRACT(HOUR FROM ${localTs})::int`;
@@ -57,6 +62,8 @@ export async function GET(request: Request) {
     .select({
       date: dateExpr,
       hour: hourExpr,
+      dispositivoId: conteo.dispositivoId,
+      dispositivoNombre: dispositivo.nombre,
       count: sql<number>`COUNT(*)::int`,
       // MIN/MAX sobre el ts real, convirtiendo después (correcto en cambios de DST)
       firstMin: sql<number>`(
@@ -69,6 +76,7 @@ export async function GET(request: Request) {
       )::int`,
     })
     .from(conteo)
+    .innerJoin(dispositivo, eq(dispositivo.id, conteo.dispositivoId))
     .where(
       and(
         inArray(conteo.servicioId, servicioIds),
@@ -76,20 +84,42 @@ export async function GET(request: Request) {
         lte(conteo.ts, hastaDate)
       )
     )
-    .groupBy(dateExpr, hourExpr)
+    .groupBy(dateExpr, hourExpr, conteo.dispositivoId, dispositivo.nombre)
     .orderBy(dateExpr, hourExpr);
 
-  const hourly = rows.map((r) => ({
+  const hourlyPorDispositivo = rows.map((r) => ({
     date: r.date,
     hour: r.hour,
+    dispositivoId: r.dispositivoId,
+    dispositivoNombre: r.dispositivoNombre,
     count: r.count,
   }));
+
+  // hourly: las mismas franjas pero sumando los dispositivos. Se recorre en el
+  // orden que vino de la DB, así que el Map preserva el orden por date, hour.
+  const porFranja = new Map<
+    string,
+    { date: string; hour: number; count: number }
+  >();
+  for (const r of rows) {
+    const key = `${r.date}|${r.hour}`;
+    const existing = porFranja.get(key);
+    if (existing) existing.count += r.count;
+    else porFranja.set(key, { date: r.date, hour: r.hour, count: r.count });
+  }
+  const hourly = Array.from(porFranja.values());
 
   let total = 0;
   // Mapa date -> { count, minStart, maxEnd } para derivar daily y jornada
   const byDate = new Map<
     string,
     { count: number; minStart: number; maxEnd: number }
+  >();
+  // Totales por dispositivo, para que el cliente arme la leyenda y el resumen
+  // sin recorrer todo el detalle.
+  const porDispositivo = new Map<
+    string,
+    { id: string; nombre: string; total: number }
   >();
   for (const r of rows) {
     total += r.count;
@@ -105,7 +135,22 @@ export async function GET(request: Request) {
         maxEnd: r.lastMin,
       });
     }
+
+    const equipo = porDispositivo.get(r.dispositivoId);
+    if (equipo) {
+      equipo.total += r.count;
+    } else {
+      porDispositivo.set(r.dispositivoId, {
+        id: r.dispositivoId,
+        nombre: r.dispositivoNombre,
+        total: r.count,
+      });
+    }
   }
+
+  const dispositivos = Array.from(porDispositivo.values()).sort(
+    (a, b) => b.total - a.total
+  );
 
   // daily ordenado por fecha (rows ya viene ordenado por date, hour)
   const daily = Array.from(byDate.entries()).map(([date, v]) => ({
@@ -134,12 +179,16 @@ export async function GET(request: Request) {
       .padStart(2, "0")}:${(avgEndMins % 60).toString().padStart(2, "0")}`;
   }
 
-  // Avg per hour: total dividido por número de franjas hora con datos
-  const totalHours = rows.length || 1;
+  // Avg per hour: total dividido por número de franjas hora con datos. Se
+  // cuenta sobre `hourly` y no sobre `rows`: con el dispositivo en el group by
+  // hay una fila por equipo y hora, y usar rows.length infla el divisor.
+  const totalHours = hourly.length || 1;
   const avgPerHour = Math.round(total / totalHours);
 
   return NextResponse.json({
     hourly,
+    hourlyPorDispositivo,
+    dispositivos,
     daily,
     total,
     avgPerHour,

--- a/my-project/src/app/app/control/page.tsx
+++ b/my-project/src/app/app/control/page.tsx
@@ -13,6 +13,7 @@ import {
   ResponsiveContainer,
   BarChart,
   Bar,
+  Legend,
 } from "recharts";
 import {
   Gauge,
@@ -29,6 +30,20 @@ interface HourlyData {
   count: number;
 }
 
+interface HourlyDispositivoData {
+  date: string;
+  hour: number;
+  dispositivoId: string;
+  dispositivoNombre: string;
+  count: number;
+}
+
+interface DispositivoResumen {
+  id: string;
+  nombre: string;
+  total: number;
+}
+
 interface DailyData {
   date: string;
   count: number;
@@ -36,6 +51,8 @@ interface DailyData {
 
 interface ProduccionResponse {
   hourly: HourlyData[];
+  hourlyPorDispositivo: HourlyDispositivoData[];
+  dispositivos: DispositivoResumen[];
   daily: DailyData[];
   total: number;
   avgPerHour: number;
@@ -61,6 +78,24 @@ interface Servicio {
 
 function formatNumber(n: number): string {
   return n.toLocaleString("es-CL");
+}
+
+// Paleta para las series por dispositivo. El primer color coincide con el cian
+// del gráfico general para que el cambio de vista no se sienta como otro
+// gráfico cuando hay un solo equipo.
+const DISPOSITIVO_COLORS = [
+  "#06b6d4",
+  "#10b981",
+  "#f59e0b",
+  "#a855f7",
+  "#ef4444",
+  "#3b82f6",
+  "#ec4899",
+  "#84cc16",
+];
+
+function colorForIndex(i: number): string {
+  return DISPOSITIVO_COLORS[i % DISPOSITIVO_COLORS.length];
 }
 
 const DOW = ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"];
@@ -169,6 +204,9 @@ export default function ControlOperacionalPage() {
   const [selectedProceso, setSelectedProceso] = useState<string>("");
   const [servicios, setServicios] = useState<Servicio[]>([]);
   const [selectedServicio, setSelectedServicio] = useState<string>("");
+  const [vistaHora, setVistaHora] = useState<"general" | "dispositivo">(
+    "general"
+  );
 
   // Fetch procesos for filter
   useEffect(() => {
@@ -235,6 +273,34 @@ export default function ControlOperacionalPage() {
     }));
   }, [produccion]);
 
+  // Una serie por dispositivo, cada una con sus puntos (hora, conteo). Recharts
+  // pinta un <Scatter> por serie, así que el agrupado se hace acá.
+  const seriesPorDispositivo = useMemo(() => {
+    if (!produccion) return [];
+    const porId = new Map<
+      string,
+      { hour: number; count: number; date: string; nombre: string }[]
+    >();
+    for (const row of produccion.hourlyPorDispositivo) {
+      const punto = {
+        hour: row.hour,
+        count: row.count,
+        date: row.date,
+        nombre: row.dispositivoNombre,
+      };
+      const puntos = porId.get(row.dispositivoId);
+      if (puntos) puntos.push(punto);
+      else porId.set(row.dispositivoId, [punto]);
+    }
+    return produccion.dispositivos.map((d, i) => ({
+      id: d.id,
+      nombre: d.nombre,
+      total: d.total,
+      color: colorForIndex(i),
+      puntos: porId.get(d.id) ?? [],
+    }));
+  }, [produccion]);
+
   // Mensaje de carga fijo por sesión (sin parpadeo entre refetches)
   const [mensajeCarga] = useState(
     () => MENSAJES_CARGA[Math.floor(Math.random() * MENSAJES_CARGA.length)]
@@ -242,6 +308,7 @@ export default function ControlOperacionalPage() {
 
   const isHorario = range === "1h" || range === "today";
   const isAnual = range === "year";
+  const porDispositivo = isHorario && vistaHora === "dispositivo";
 
   // Agregación mensual para el rango "año" (evita 365 puntos)
   const monthlyData = useMemo(() => {
@@ -408,7 +475,7 @@ export default function ControlOperacionalPage() {
                   <p className="text-xs text-slate-500">Inicio promedio</p>
                 </div>
                 <p className="text-2xl font-bold text-cyan-400 font-mono">
-                  {produccion.avgStartTime ?? "\u2014"}
+                  {produccion.avgStartTime ?? "—"}
                 </p>
               </CardContent>
             </Card>
@@ -420,7 +487,7 @@ export default function ControlOperacionalPage() {
                   <p className="text-xs text-slate-500">Termino promedio</p>
                 </div>
                 <p className="text-2xl font-bold text-orange-400 font-mono">
-                  {produccion.avgEndTime ?? "\u2014"}
+                  {produccion.avgEndTime ?? "—"}
                 </p>
               </CardContent>
             </Card>
@@ -429,17 +496,115 @@ export default function ControlOperacionalPage() {
           {/* Gráfico principal: detalle por hora (Hoy) o tendencia por día/mes */}
           <Card className="bg-slate-900/40 border-white/10">
             <CardHeader className="pb-2">
-              <CardTitle className="text-base text-white">
-                {isHorario
-                  ? "Producción por hora del día"
-                  : isAnual
-                  ? "Producción por mes"
-                  : "Producción por día"}
-              </CardTitle>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <CardTitle className="text-base text-white">
+                  {isHorario
+                    ? "Producción por hora del día"
+                    : isAnual
+                    ? "Producción por mes"
+                    : "Producción por día"}
+                </CardTitle>
+
+                {/* Cambio de vista: total de la empresa vs desglose por equipo.
+                    Solo en los rangos horarios — en día/mes el gráfico es de
+                    barras agregadas y el desglose no aplica. */}
+                {isHorario && (
+                  <div className="flex rounded-full border border-white/10 bg-slate-950/40 p-0.5">
+                    {(
+                      [
+                        { value: "general", label: "General" },
+                        { value: "dispositivo", label: "Por dispositivo" },
+                      ] as const
+                    ).map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => setVistaHora(opt.value)}
+                        className={`px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 ${
+                          vistaHora === opt.value
+                            ? "bg-cyan-950/70 text-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.15)]"
+                            : "text-slate-400 hover:text-slate-200"
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </CardHeader>
             <CardContent>
               {isHorario ? (
-                scatterData.length === 0 ? (
+                porDispositivo ? (
+                  seriesPorDispositivo.length === 0 ? (
+                    <div className="h-[300px] flex items-center justify-center text-slate-500 text-sm">
+                      Sin datos por dispositivo en este periodo
+                    </div>
+                  ) : (
+                    <ResponsiveContainer width="100%" height={300}>
+                      <ScatterChart margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                        <XAxis
+                          type="number"
+                          dataKey="hour"
+                          domain={[0, 23]}
+                          ticks={Array.from({ length: 24 }, (_, i) => i)}
+                          tick={{ fill: "#64748b", fontSize: 11 }}
+                          tickFormatter={(v) => `${v}:00`}
+                          label={{
+                            value: "Hora",
+                            position: "insideBottomRight",
+                            offset: -5,
+                            fill: "#64748b",
+                            fontSize: 11,
+                          }}
+                        />
+                        <YAxis
+                          type="number"
+                          dataKey="count"
+                          tick={{ fill: "#64748b", fontSize: 11 }}
+                          tickFormatter={(v) => v.toLocaleString("es-CL")}
+                        />
+                        <Tooltip
+                          cursor={{ strokeDasharray: "3 3" }}
+                          content={({ active, payload }) => {
+                            if (!active || !payload?.length) return null;
+                            const p = payload[0].payload as {
+                              hour: number;
+                              count: number;
+                              date: string;
+                              nombre: string;
+                            };
+                            return (
+                              <div className="rounded-lg border border-white/10 bg-[#0f172a] px-3 py-2 text-xs">
+                                <div className="text-slate-300">{p.nombre}</div>
+                                <div className="text-slate-400">
+                                  {fechaLarga(p.date)} · {p.hour}:00
+                                </div>
+                                <div className="text-slate-200">
+                                  {formatNumber(p.count)} bulbos
+                                </div>
+                              </div>
+                            );
+                          }}
+                        />
+                        <Legend
+                          wrapperStyle={{ fontSize: 11, paddingTop: 8 }}
+                          iconType="circle"
+                        />
+                        {seriesPorDispositivo.map((s) => (
+                          <Scatter
+                            key={s.id}
+                            name={s.nombre}
+                            data={s.puntos}
+                            fill={s.color}
+                            fillOpacity={0.7}
+                            r={5}
+                          />
+                        ))}
+                      </ScatterChart>
+                    </ResponsiveContainer>
+                  )
+                ) : scatterData.length === 0 ? (
                   <div className="h-[300px] flex items-center justify-center text-slate-500 text-sm">
                     Sin datos en este periodo
                   </div>
@@ -553,6 +718,37 @@ export default function ControlOperacionalPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* Resumen por dispositivo, visible solo en la vista desglosada */}
+          {porDispositivo && seriesPorDispositivo.length > 0 && (
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+              {seriesPorDispositivo.map((s) => (
+                <Card key={s.id} className="bg-slate-900/40 border-white/10">
+                  <CardContent className="p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span
+                        className="w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: s.color }}
+                      />
+                      <p
+                        className="text-xs text-slate-400 truncate"
+                        title={s.nombre}
+                      >
+                        {s.nombre}
+                      </p>
+                    </div>
+                    <p className="text-xl font-bold text-white">
+                      {formatNumber(s.total)}
+                    </p>
+                    <p className="text-[11px] text-slate-500 mt-0.5">
+                      {formatNumber(Math.round(s.total / (s.puntos.length || 1)))}{" "}
+                      /hora
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
 
           {/* Secundario: producción acumulada por hora (patrón de jornada) */}
           <Card className="bg-slate-900/40 border-white/10">


### PR DESCRIPTION
Control Operacional solo mostraba la produccion horaria agregada de toda la empresa. Ahora la tarjeta "Produccion por hora del dia" tiene un toggle General / Por dispositivo.

- API: nueva agregacion por (dia, hora, dispositivo) con join a dispositivo para el nombre, mas una lista de dispositivos con su total ordenada de mayor a menor. La suma se hace en Postgres, no en el cliente.
- UI: en la vista desglosada, una serie de scatter por equipo con su color y leyenda, mas tarjetas de resumen con total y promedio/hora por equipo. Ejes y dominio de horas identicos entre vistas para que alternar no reacomode el grafico.