### PR TITLE
fix: no perder entregas cortadas por el deadline y no destruir agregados de caja compartidos

### DIFF
--- a/my-project/scripts/delete-conteos-lotes.ts
+++ b/my-project/scripts/delete-conteos-lotes.ts
@@ -101,6 +101,48 @@ async function readAggregates(sql: Sql, loteIds: string[]) {
   return row;
 }
 
+/** Sesiones de caja del lote, sin importar a que servicio pertenecen. */
+function cajaSessionsOfLote(sql: Sql, loteId: string) {
+  return sql`
+    SELECT cls.id FROM caja_lote_session cls
+    JOIN lote_session ls ON ls.id = cls.lote_session_id
+    WHERE ls.lote_id = ${loteId}
+  `;
+}
+
+async function rebuildCajaStats(sql: Sql, loteId: string) {
+  const deleted = await sql`
+    DELETE FROM caja_stats
+    WHERE caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
+  `;
+  await sql`
+    INSERT INTO caja_stats (caja_lote_session_id, dispositivo_id, calibre, count_in, count_out, first_ts, last_ts)
+    SELECT c.caja_lote_session_id, c.dispositivo_id, ROUND(c.perimeter::numeric, 1)::real,
+      SUM((c.direction = 0)::int)::int, SUM((c.direction = 1)::int)::int, MIN(c.ts), MAX(c.ts)
+    FROM conteo c
+    WHERE c.caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
+      AND c.perimeter IS NOT NULL
+    GROUP BY 1, 2, 3
+  `;
+  return deleted.count;
+}
+
+async function rebuildCajaTotalStats(sql: Sql, loteId: string) {
+  const deleted = await sql`
+    DELETE FROM caja_total_stats
+    WHERE caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
+  `;
+  await sql`
+    INSERT INTO caja_total_stats (caja_lote_session_id, dispositivo_id, count_in, count_out, first_ts, last_ts)
+    SELECT c.caja_lote_session_id, c.dispositivo_id,
+      SUM((c.direction = 0)::int)::int, SUM((c.direction = 1)::int)::int, MIN(c.ts), MAX(c.ts)
+    FROM conteo c
+    WHERE c.caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
+    GROUP BY 1, 2
+  `;
+  return deleted.count;
+}
+
 async function deleteLote(sql: Sql, scope: LoteScope) {
   await sql.begin(async (tx) => {
     const del = tx as unknown as Sql;
@@ -112,20 +154,13 @@ async function deleteLote(sql: Sql, scope: LoteScope) {
       DELETE FROM conteo WHERE lote_id = ${scope.lote_id} AND servicio_id = ${SERVICE_ID}
     `;
 
-    const cajaStats = await del`
-      DELETE FROM caja_stats WHERE caja_lote_session_id IN (
-        SELECT cls.id FROM caja_lote_session cls
-        JOIN lote_session ls ON ls.id = cls.lote_session_id
-        WHERE ls.lote_id = ${scope.lote_id}
-      )
-    `;
-    const cajaTotalStats = await del`
-      DELETE FROM caja_total_stats WHERE caja_lote_session_id IN (
-        SELECT cls.id FROM caja_lote_session cls
-        JOIN lote_session ls ON ls.id = cls.lote_session_id
-        WHERE ls.lote_id = ${scope.lote_id}
-      )
-    `;
+    // caja_stats y caja_total_stats no tienen servicio_id: una misma sesion de
+    // caja puede acumular conteos de varios servicios. Por eso no se borran, se
+    // reconstruyen desde los conteos que sobreviven — si no queda ninguno el
+    // INSERT no aporta filas y el efecto es el mismo que borrarlas. La
+    // definicion replica la del trigger `update_lote_stats` (migracion 0018).
+    const cajaStats = await rebuildCajaStats(del, scope.lote_id);
+    const cajaTotalStats = await rebuildCajaTotalStats(del, scope.lote_id);
     const loteStats = await del`
       DELETE FROM lote_stats WHERE lote_id = ${scope.lote_id} AND servicio_id = ${SERVICE_ID}
     `;
@@ -140,30 +175,65 @@ async function deleteLote(sql: Sql, scope: LoteScope) {
 
     console.log(
       `  ${scope.codigo_lote}: conteo ${conteos.count} · lote_stats ${loteStats.count} · ` +
-        `lote_total_stats ${loteTotalStats.count} · caja_stats ${cajaStats.count} · ` +
-        `caja_total_stats ${cajaTotalStats.count} · declarado_dia ${declaradoDia.count}`
+        `lote_total_stats ${loteTotalStats.count} · caja_stats ${cajaStats} recalc · ` +
+        `caja_total_stats ${cajaTotalStats} recalc · declarado_dia ${declaradoDia.count}`
     );
   });
 }
 
-/** Corre dentro de la transaccion: si algo sobrevive, lanza y hace rollback. */
+/** Corre dentro de la transaccion: si algo no cuadra, lanza y hace rollback. */
 async function validateLote(sql: Sql, loteId: string) {
   const [row] = await sql<{ total: number }[]>`
-    WITH cajas AS (
-      SELECT cls.id FROM caja_lote_session cls
-      JOIN lote_session ls ON ls.id = cls.lote_session_id
-      WHERE ls.lote_id = ${loteId}
-    )
     SELECT (
       (SELECT COUNT(*) FROM conteo WHERE lote_id = ${loteId} AND servicio_id = ${SERVICE_ID}) +
       (SELECT COUNT(*) FROM lote_stats WHERE lote_id = ${loteId} AND servicio_id = ${SERVICE_ID}) +
       (SELECT COUNT(*) FROM lote_total_stats WHERE lote_id = ${loteId} AND servicio_id = ${SERVICE_ID}) +
-      (SELECT COUNT(*) FROM caja_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)) +
-      (SELECT COUNT(*) FROM caja_total_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)) +
       (SELECT COUNT(*) FROM lote_calibre_declarado_dia WHERE lote_id = ${loteId} AND servicio_id = ${SERVICE_ID})
     )::int AS total
   `;
   if (row.total !== 0) throw new Error(`Quedaron ${row.total} filas para el lote ${loteId}`);
+
+  // Los agregados de caja se reconstruyeron, no se borraron: deben cuadrar
+  // exactamente con los conteos que sobrevivieron (de este lote en otros
+  // servicios), no quedar en cero.
+  const cajaMismatches = await sql`
+    WITH cajas AS (
+      SELECT cls.id FROM caja_lote_session cls
+      JOIN lote_session ls ON ls.id = cls.lote_session_id
+      WHERE ls.lote_id = ${loteId}
+    ), esperado AS (
+      SELECT caja_lote_session_id, dispositivo_id,
+        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
+      FROM conteo WHERE caja_lote_session_id IN (SELECT id FROM cajas)
+      GROUP BY 1, 2
+    ), actual AS (
+      SELECT caja_lote_session_id, dispositivo_id, count_in, count_out
+      FROM caja_total_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)
+    )
+    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id)
+    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
+  `;
+  if (cajaMismatches.length) throw new Error(`caja_total_stats no cuadra con conteo en ${loteId}`);
+
+  const cajaCalibreMismatches = await sql`
+    WITH cajas AS (
+      SELECT cls.id FROM caja_lote_session cls
+      JOIN lote_session ls ON ls.id = cls.lote_session_id
+      WHERE ls.lote_id = ${loteId}
+    ), esperado AS (
+      SELECT caja_lote_session_id, dispositivo_id, ROUND(perimeter::numeric, 1)::real AS calibre,
+        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
+      FROM conteo
+      WHERE caja_lote_session_id IN (SELECT id FROM cajas) AND perimeter IS NOT NULL
+      GROUP BY 1, 2, 3
+    ), actual AS (
+      SELECT caja_lote_session_id, dispositivo_id, calibre, count_in, count_out
+      FROM caja_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)
+    )
+    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id, calibre)
+    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
+  `;
+  if (cajaCalibreMismatches.length) throw new Error(`caja_stats no cuadra con conteo en ${loteId}`);
 
   const [link] = await sql<{ count: number }[]>`
     SELECT COUNT(*)::int AS count FROM lote_servicio
@@ -207,7 +277,8 @@ async function main() {
     if (conFugas.length) {
       console.warn(
         `Aviso: ${conFugas.map((scope) => scope.codigo_lote).join(", ")} tienen conteos en otros ` +
-          `servicios; esos NO se tocan, pero sus caja_stats si se borran (son por sesion de caja).`
+          `servicios. Esos conteos NO se tocan y sus agregados de caja se recalculan a partir ` +
+          `de lo que sobrevive, porque caja_stats no distingue servicio.`
       );
     }
     if (!apply) return;

--- a/my-project/scripts/delete-conteos-lotes.ts
+++ b/my-project/scripts/delete-conteos-lotes.ts
@@ -101,46 +101,105 @@ async function readAggregates(sql: Sql, loteIds: string[]) {
   return row;
 }
 
-/** Sesiones de caja del lote, sin importar a que servicio pertenecen. */
-function cajaSessionsOfLote(sql: Sql, loteId: string) {
-  return sql`
+/** Sesiones de caja de los lotes del scope, sin importar a que servicio pertenecen. */
+async function readCajaSessionIds(sql: Sql, loteIds: string[]) {
+  const rows = await sql<{ id: string }[]>`
     SELECT cls.id FROM caja_lote_session cls
     JOIN lote_session ls ON ls.id = cls.lote_session_id
-    WHERE ls.lote_id = ${loteId}
+    WHERE ls.lote_id = ANY(${loteIds}::uuid[])
   `;
+  return rows.map((row) => row.id);
 }
 
-async function rebuildCajaStats(sql: Sql, loteId: string) {
-  const deleted = await sql`
-    DELETE FROM caja_stats
-    WHERE caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
-  `;
-  await sql`
-    INSERT INTO caja_stats (caja_lote_session_id, dispositivo_id, calibre, count_in, count_out, first_ts, last_ts)
-    SELECT c.caja_lote_session_id, c.dispositivo_id, ROUND(c.perimeter::numeric, 1)::real,
-      SUM((c.direction = 0)::int)::int, SUM((c.direction = 1)::int)::int, MIN(c.ts), MAX(c.ts)
-    FROM conteo c
-    WHERE c.caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
-      AND c.perimeter IS NOT NULL
-    GROUP BY 1, 2, 3
-  `;
-  return deleted.count;
+/**
+ * Reconstruye los agregados de caja de todos los lotes del scope, en UNA sola
+ * pasada sobre `conteo`.
+ *
+ * `conteo` no tiene indice por `caja_lote_session_id` (los indices son por
+ * lote, servicio y dispositivo), asi que cualquier lectura por sesion de caja
+ * es un seq scan de 16 GB. Hacerlo por lote y por tabla eran cuatro scans por
+ * lote, con la transaccion de borrado abierta.
+ *
+ * Tampoco se puede acotar con `lote_id`: hay 1,7M de conteos cuyo
+ * `caja_lote_session_id` pertenece a una `lote_session` de OTRO lote, asi que
+ * ese filtro dejaria los agregados cortos. Por eso se vuelca una sola vez lo
+ * que referencia a estas sesiones —despues del borrado suele ser muy poco o
+ * nada— y desde ahi se reconstruye y se valida.
+ */
+async function rebuildCajaAggregates(sql: Sql, sessionIds: string[]) {
+  if (sessionIds.length === 0) return { cajaStats: 0, cajaTotalStats: 0, sobrevivientes: 0 };
+
+  return sql.begin(async (tx) => {
+    const db = tx as unknown as Sql;
+    await db`
+      CREATE TEMP TABLE tmp_caja_conteo ON COMMIT DROP AS
+      SELECT caja_lote_session_id, dispositivo_id, perimeter, direction, ts
+      FROM conteo WHERE caja_lote_session_id = ANY(${sessionIds}::uuid[])
+    `;
+    const [{ count: sobrevivientes }] = await db<{ count: number }[]>`
+      SELECT COUNT(*)::int AS count FROM tmp_caja_conteo
+    `;
+
+    const cajaStats = await db`
+      DELETE FROM caja_stats WHERE caja_lote_session_id = ANY(${sessionIds}::uuid[])
+    `;
+    const cajaTotalStats = await db`
+      DELETE FROM caja_total_stats WHERE caja_lote_session_id = ANY(${sessionIds}::uuid[])
+    `;
+
+    // Replica la definicion del trigger `update_lote_stats` (migracion 0018).
+    await db`
+      INSERT INTO caja_stats (caja_lote_session_id, dispositivo_id, calibre, count_in, count_out, first_ts, last_ts)
+      SELECT caja_lote_session_id, dispositivo_id, ROUND(perimeter::numeric, 1)::real,
+        SUM((direction = 0)::int)::int, SUM((direction = 1)::int)::int, MIN(ts), MAX(ts)
+      FROM tmp_caja_conteo WHERE perimeter IS NOT NULL
+      GROUP BY 1, 2, 3
+    `;
+    await db`
+      INSERT INTO caja_total_stats (caja_lote_session_id, dispositivo_id, count_in, count_out, first_ts, last_ts)
+      SELECT caja_lote_session_id, dispositivo_id,
+        SUM((direction = 0)::int)::int, SUM((direction = 1)::int)::int, MIN(ts), MAX(ts)
+      FROM tmp_caja_conteo
+      GROUP BY 1, 2
+    `;
+
+    await validateCajaAggregates(db, sessionIds);
+    return { cajaStats: cajaStats.count, cajaTotalStats: cajaTotalStats.count, sobrevivientes };
+  });
 }
 
-async function rebuildCajaTotalStats(sql: Sql, loteId: string) {
-  const deleted = await sql`
-    DELETE FROM caja_total_stats
-    WHERE caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
+/**
+ * Valida contra el volcado temporal, que es exactamente lo que `conteo` tiene
+ * para estas sesiones, leido una sola vez. Si no cuadra, lanza y hace rollback.
+ */
+async function validateCajaAggregates(sql: Sql, sessionIds: string[]) {
+  const totalMismatches = await sql`
+    WITH esperado AS (
+      SELECT caja_lote_session_id, dispositivo_id,
+        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
+      FROM tmp_caja_conteo GROUP BY 1, 2
+    ), actual AS (
+      SELECT caja_lote_session_id, dispositivo_id, count_in, count_out
+      FROM caja_total_stats WHERE caja_lote_session_id = ANY(${sessionIds}::uuid[])
+    )
+    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id)
+    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
   `;
-  await sql`
-    INSERT INTO caja_total_stats (caja_lote_session_id, dispositivo_id, count_in, count_out, first_ts, last_ts)
-    SELECT c.caja_lote_session_id, c.dispositivo_id,
-      SUM((c.direction = 0)::int)::int, SUM((c.direction = 1)::int)::int, MIN(c.ts), MAX(c.ts)
-    FROM conteo c
-    WHERE c.caja_lote_session_id IN (${cajaSessionsOfLote(sql, loteId)})
-    GROUP BY 1, 2
+  if (totalMismatches.length) throw new Error("caja_total_stats no cuadra con conteo");
+
+  const calibreMismatches = await sql`
+    WITH esperado AS (
+      SELECT caja_lote_session_id, dispositivo_id, ROUND(perimeter::numeric, 1)::real AS calibre,
+        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
+      FROM tmp_caja_conteo WHERE perimeter IS NOT NULL GROUP BY 1, 2, 3
+    ), actual AS (
+      SELECT caja_lote_session_id, dispositivo_id, calibre, count_in, count_out
+      FROM caja_stats WHERE caja_lote_session_id = ANY(${sessionIds}::uuid[])
+    )
+    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id, calibre)
+    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
   `;
-  return deleted.count;
+  if (calibreMismatches.length) throw new Error("caja_stats no cuadra con conteo");
 }
 
 async function deleteLote(sql: Sql, scope: LoteScope) {
@@ -154,13 +213,10 @@ async function deleteLote(sql: Sql, scope: LoteScope) {
       DELETE FROM conteo WHERE lote_id = ${scope.lote_id} AND servicio_id = ${SERVICE_ID}
     `;
 
-    // caja_stats y caja_total_stats no tienen servicio_id: una misma sesion de
-    // caja puede acumular conteos de varios servicios. Por eso no se borran, se
-    // reconstruyen desde los conteos que sobreviven — si no queda ninguno el
-    // INSERT no aporta filas y el efecto es el mismo que borrarlas. La
-    // definicion replica la del trigger `update_lote_stats` (migracion 0018).
-    const cajaStats = await rebuildCajaStats(del, scope.lote_id);
-    const cajaTotalStats = await rebuildCajaTotalStats(del, scope.lote_id);
+    // Los agregados de caja NO se tocan aca: no tienen servicio_id y su lectura
+    // es un seq scan, asi que se reconstruyen todos juntos en una sola pasada
+    // al final (ver rebuildCajaAggregates). Estas tres tablas si llevan
+    // servicio_id y se borran por indice.
     const loteStats = await del`
       DELETE FROM lote_stats WHERE lote_id = ${scope.lote_id} AND servicio_id = ${SERVICE_ID}
     `;
@@ -175,8 +231,7 @@ async function deleteLote(sql: Sql, scope: LoteScope) {
 
     console.log(
       `  ${scope.codigo_lote}: conteo ${conteos.count} · lote_stats ${loteStats.count} · ` +
-        `lote_total_stats ${loteTotalStats.count} · caja_stats ${cajaStats} recalc · ` +
-        `caja_total_stats ${cajaTotalStats} recalc · declarado_dia ${declaradoDia.count}`
+        `lote_total_stats ${loteTotalStats.count} · declarado_dia ${declaradoDia.count}`
     );
   });
 }
@@ -192,48 +247,6 @@ async function validateLote(sql: Sql, loteId: string) {
     )::int AS total
   `;
   if (row.total !== 0) throw new Error(`Quedaron ${row.total} filas para el lote ${loteId}`);
-
-  // Los agregados de caja se reconstruyeron, no se borraron: deben cuadrar
-  // exactamente con los conteos que sobrevivieron (de este lote en otros
-  // servicios), no quedar en cero.
-  const cajaMismatches = await sql`
-    WITH cajas AS (
-      SELECT cls.id FROM caja_lote_session cls
-      JOIN lote_session ls ON ls.id = cls.lote_session_id
-      WHERE ls.lote_id = ${loteId}
-    ), esperado AS (
-      SELECT caja_lote_session_id, dispositivo_id,
-        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
-      FROM conteo WHERE caja_lote_session_id IN (SELECT id FROM cajas)
-      GROUP BY 1, 2
-    ), actual AS (
-      SELECT caja_lote_session_id, dispositivo_id, count_in, count_out
-      FROM caja_total_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)
-    )
-    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id)
-    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
-  `;
-  if (cajaMismatches.length) throw new Error(`caja_total_stats no cuadra con conteo en ${loteId}`);
-
-  const cajaCalibreMismatches = await sql`
-    WITH cajas AS (
-      SELECT cls.id FROM caja_lote_session cls
-      JOIN lote_session ls ON ls.id = cls.lote_session_id
-      WHERE ls.lote_id = ${loteId}
-    ), esperado AS (
-      SELECT caja_lote_session_id, dispositivo_id, ROUND(perimeter::numeric, 1)::real AS calibre,
-        SUM((direction = 0)::int)::int AS count_in, SUM((direction = 1)::int)::int AS count_out
-      FROM conteo
-      WHERE caja_lote_session_id IN (SELECT id FROM cajas) AND perimeter IS NOT NULL
-      GROUP BY 1, 2, 3
-    ), actual AS (
-      SELECT caja_lote_session_id, dispositivo_id, calibre, count_in, count_out
-      FROM caja_stats WHERE caja_lote_session_id IN (SELECT id FROM cajas)
-    )
-    SELECT 1 FROM esperado e FULL OUTER JOIN actual a USING (caja_lote_session_id, dispositivo_id, calibre)
-    WHERE e.count_in IS DISTINCT FROM a.count_in OR e.count_out IS DISTINCT FROM a.count_out
-  `;
-  if (cajaCalibreMismatches.length) throw new Error(`caja_stats no cuadra con conteo en ${loteId}`);
 
   const [link] = await sql<{ count: number }[]>`
     SELECT COUNT(*)::int AS count FROM lote_servicio
@@ -283,9 +296,19 @@ async function main() {
     }
     if (!apply) return;
 
+    const sessionIds = await readCajaSessionIds(sql, loteIds);
+
     for (const scope of scopes) {
       await deleteLote(sql, scope);
     }
+
+    // Una sola pasada al final, ya con los conteos borrados: es la unica
+    // lectura por sesion de caja de toda la corrida.
+    const caja = await rebuildCajaAggregates(sql, sessionIds);
+    console.log(
+      `  agregados de caja: ${sessionIds.length} sesiones · ${caja.cajaStats} caja_stats y ` +
+        `${caja.cajaTotalStats} caja_total_stats recalculados desde ${caja.sobrevivientes} conteos sobrevivientes`
+    );
 
     // El borrado deja ~1,2M tuplas muertas: refrescar estadisticas para que el
     // planner no siga estimando con los conteos viejos. El espacio lo recupera

--- a/my-project/src/app/api/internal/reports/daily/route.ts
+++ b/my-project/src/app/api/internal/reports/daily/route.ts
@@ -54,15 +54,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "\"dates\" requiere \"force\": true" }, { status: 400 });
   }
 
+  // Las pasadas de 19:10 a 21:10 repiten el trabajo completo: crean lo que
+  // falte y retoman lo pending/failed (o un 'sending' de mas de 30 min). No se
+  // limitan a reintentar, porque el corte por deadline puede haber dejado
+  // servicios enteros sin fila en report_delivery, y esos solo se recuperan si
+  // una pasada posterior los inserta. Lo ya enviado nunca se reenvia.
   const hour = localHour();
   if (!force && (hour < REPORTING_HOUR || hour > RETRY_UNTIL_HOUR)) {
     return NextResponse.json({ skipped: true, reason: "outside_reporting_window", hour });
   }
-  // A las 18:10 se crean y envian las entregas del dia; entre las 19:10 y las
-  // 21:10 solo se retoman las que quedaron pending/failed (o un 'sending' de
-  // mas de 30 min). Antes un fallo a las 18:10 no se reintentaba hasta el dia
-  // siguiente. Un disparo manual siempre entra en modo completo.
-  const retriesOnly = !force && hour > REPORTING_HOUR;
 
   const reportDates = manualDates.length > 0 ? manualDates : automaticReportDates();
   if (reportDates.length === 0) {
@@ -70,12 +70,12 @@ export async function POST(request: Request) {
   }
 
   // Secuencial y con presupuesto: los lunes son tres fechas compitiendo por los
-  // mismos 60 s de maxDuration. Lo que no alcance queda registrado en
-  // report_delivery y lo toma la pasada de reintento.
+  // mismos 60 s de maxDuration. Lo que no alcance lo retoma la pasada siguiente,
+  // que vuelve a recorrer servicios y fechas desde cero.
   const deadline = Date.now() + BUDGET_MS;
   const runs = [] as Awaited<ReturnType<typeof dispatchDailyReports>>[];
   for (const reportDate of reportDates) {
-    runs.push(await dispatchDailyReports(reportDate, { retriesOnly, deadline }));
+    runs.push(await dispatchDailyReports(reportDate, { deadline }));
     if (Date.now() > deadline) break;
   }
   const result = runs.reduce(
@@ -94,7 +94,7 @@ export async function POST(request: Request) {
   if (result.failed > 0) {
     console.error(`[reporting] ${result.failed} entregas fallidas`, result.errors);
   } else {
-    console.log(`[reporting] ${JSON.stringify({ reportDates, retriesOnly, ...result, errors: undefined })}`);
+    console.log(`[reporting] ${JSON.stringify({ reportDates, ...result, errors: undefined })}`);
   }
-  return NextResponse.json({ ok: true, reportDates, retriesOnly, runs, ...result });
+  return NextResponse.json({ ok: true, reportDates, runs, ...result });
 }

--- a/my-project/src/lib/reporting/dispatch.ts
+++ b/my-project/src/lib/reporting/dispatch.ts
@@ -46,26 +46,22 @@ export async function buildReportPair(serviceId: string, reportDate: string): Pr
 }
 
 /**
- * `retriesOnly` omite la creacion de entregas nuevas y solo reabre las que
- * quedaron a medias. Lo usan las pasadas de reintento (09:00-11:00), que no
- * deben inventar destinatarios sino terminar lo que fallo a las 08:00.
+ * Reserva una entrega, creandola si no existe.
+ *
+ * Cada pasada crea lo que falte: el corte por deadline puede dejar servicios o
+ * fechas sin fila, y esas entregas solo pueden recuperarse si una pasada
+ * posterior las inserta. Los duplicados los impide el estado, no el saltarse el
+ * insert: el UPDATE de abajo nunca toca una fila `sent`.
  */
-async function reserveDelivery(
-  serviceId: string,
-  email: string,
-  reportDate: string,
-  retriesOnly = false
-) {
+async function reserveDelivery(serviceId: string, email: string, reportDate: string) {
   const date = dateValue(reportDate);
-  const [inserted] = retriesOnly
-    ? []
-    : await db
-        .insert(reportDelivery)
-        .values({ servicioId: serviceId, recipientCorreo: email, reportDate: date })
-        .onConflictDoNothing({
-          target: [reportDelivery.servicioId, reportDelivery.recipientCorreo, reportDelivery.reportDate],
-        })
-        .returning({ id: reportDelivery.id });
+  const [inserted] = await db
+    .insert(reportDelivery)
+    .values({ servicioId: serviceId, recipientCorreo: email, reportDate: date })
+    .onConflictDoNothing({
+      target: [reportDelivery.servicioId, reportDelivery.recipientCorreo, reportDelivery.reportDate],
+    })
+    .returning({ id: reportDelivery.id });
 
   if (inserted) {
     const [sending] = await db
@@ -199,9 +195,9 @@ async function refreshDeclaredSummary(serviceId: string, reportDate: string) {
 
 export async function dispatchDailyReports(
   reportDate: string,
-  options: { retriesOnly?: boolean; deadline?: number } = {}
+  options: { deadline?: number } = {}
 ) {
-  const { retriesOnly = false, deadline } = options;
+  const { deadline } = options;
   const outOfTime = () => deadline !== undefined && Date.now() > deadline;
   const day = localDayRange(reportDate);
   const services = await db
@@ -247,7 +243,7 @@ export async function dispatchDailyReports(
     // instead of silently losing the service with no delivery record.
     const reserved = [] as Array<{ recipient: (typeof recipients)[number]; deliveryId: string }>;
     for (const recipient of recipients) {
-      const delivery = await reserveDelivery(service.id, recipient.correo, reportDate, retriesOnly);
+      const delivery = await reserveDelivery(service.id, recipient.correo, reportDate);
       if (delivery) reserved.push({ recipient, deliveryId: delivery.id });
       else skipped += 1;
     }


### PR DESCRIPTION
Dos defectos introducidos en #78.

## 1. Entregas cortadas por el deadline se perdían para siempre

`dispatchDailyReports` corta con `break` al agotar el presupuesto **antes** de reservar las entregas de los servicios y fechas restantes. Como las pasadas de 19:10 a 21:10 usaban `retriesOnly`, `reserveDelivery` se saltaba el `INSERT` y esas filas nunca llegaban a existir: no había nada que reintentar. El informe quedaba omitido de forma permanente, justo al revés de lo que prometía el comentario. El escenario más probable era el lunes, con tres fechas compitiendo por los mismos 60 s.

`retriesOnly` nunca fue necesario para evitar duplicados: la unicidad de `(servicio_id, recipient_correo, report_date)` más el filtro de estados ya lo garantizan, porque el `UPDATE` solo reabre `pending`/`failed`/`sending` rancio y nunca toca una fila `sent`. Se elimina, y cada pasada vuelve a recorrer servicios y fechas creando lo que falte.

## 2. `caja_stats` compartido se borraba en vez de recalcularse

`caja_stats` y `caja_total_stats` se agregan por `caja_lote_session_id` y **no tienen `servicio_id`**. El script borraba las filas de todas las sesiones de caja del lote, aunque los conteos de otros servicios se conserven a propósito. Con un lote presente en dos servicios, `/api/cajas/calibres` y `/api/cajas/session` habrían informado totales faltantes para conteos que siguen existiendo. El script solo advertía la condición.

Ahora esas filas se reconstruyen desde los conteos que sobreviven, replicando la definición del trigger `update_lote_stats` (migración 0018). Si no queda ninguno el `INSERT` no aporta filas y el efecto es el mismo que borrarlas, así que el caso simple no cambia. La validación pasa de exigir cero a comparar los agregados contra `conteo`, y hace rollback si no cuadran.

`lote_stats`, `lote_total_stats` y `lote_calibre_declarado_dia` sí llevan `servicio_id` y se siguen borrando por `(lote, servicio)`, que es correcto.

## Impacto en producción

Ninguno sobre lo ya ejecutado: los 5 lotes borrados tenían `conteos_otros_servicios = 0`, así que ninguna sesión de caja era compartida. El dry-run vuelve a dar cero en todo, o sea el estado quedó consistente.

## Verificación

`npm run build` limpio y dry-run del script contra producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)