### PR TITLE
feat(lotes/reportes): mostrar salida y su calibre en vez del nombre del dispositivo

### DIFF
--- a/my-project/src/app/api/lotes/[loteId]/detail/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/detail/route.ts
@@ -12,8 +12,19 @@ import {
   proceso,
   tipoProceso,
   dispositivo,
+  dispositivoServicio,
+  loteCierreCalibreBin,
 } from "@/db/schema";
-import { eq, and, isNull, sql, inArray } from "drizzle-orm";
+import { eq, and, isNull, isNotNull, sql, inArray } from "drizzle-orm";
+
+// El calibre puede venir con un extremo abierto (merma: "<6", ">10"), así que
+// calibreFrom/calibreTo son nullable y hay que formatear los tres casos.
+function formatCalibre(from: number | null, to: number | null): string | null {
+  if (from != null && to != null) return `${from}/${to}`;
+  if (from != null) return `${from}+`;
+  if (to != null) return `≤${to}`;
+  return null;
+}
 
 export async function GET(
   request: Request,
@@ -119,6 +130,124 @@ export async function GET(
 
   // 7. Check if any service uses cajas
   const servicioIds = lifecycle.map((l) => l.servicioId);
+
+  // 7b. Salida física de cada dispositivo y el calibre que declaró en ESTE lote.
+  //
+  // La salida vive en dispositivo_servicio (configurable por servicio, no es una
+  // propiedad del equipo), y el calibre en lote_cierre_calibre_bin — lo escribe
+  // la tablet al cerrar el lote. Por eso el calibre se resuelve por lote y no
+  // se puede cachear como atributo de la salida: la misma salida corre calibres
+  // distintos en lotes distintos.
+  const dispositivoIds = [...new Set(deviceStats.map((d) => d.dispositivoId))];
+
+  // Pares (dispositivo, servicio) que realmente tienen conteos en este lote.
+  // Es imprescindible acotar por el par y no solo por dispositivo: un equipo
+  // suele estar vinculado a varios servicios, y solo en algunos tiene salida
+  // configurada. Filtrando solo por dispositivo, la "Salida 2" de un servicio
+  // se filtraba a lotes de otro servicio que no usa salidas.
+  const paresConConteo = await db
+    .selectDistinct({
+      servicioId: loteTotalStats.servicioId,
+      dispositivoId: loteTotalStats.dispositivoId,
+    })
+    .from(loteTotalStats)
+    .where(eq(loteTotalStats.loteId, loteId));
+
+  const paresValidos = new Set(
+    paresConConteo.map((p) => `${p.dispositivoId}|${p.servicioId}`)
+  );
+
+  const salidaRows =
+    dispositivoIds.length > 0 && servicioIds.length > 0
+      ? await db
+          .select({
+            dispositivoId: dispositivoServicio.dispositivoId,
+            servicioId: dispositivoServicio.servicioId,
+            salidaOrden: dispositivoServicio.salidaOrden,
+            salidaNombre: dispositivoServicio.salidaNombre,
+          })
+          .from(dispositivoServicio)
+          .where(
+            and(
+              inArray(dispositivoServicio.dispositivoId, dispositivoIds),
+              inArray(dispositivoServicio.servicioId, servicioIds)
+            )
+          )
+      : [];
+
+  // Un mismo dispositivo puede tener conteos en más de un servicio del lote
+  // (raro: 1 de 270 casos en datos reales). Nos quedamos con el vínculo que sí
+  // tiene salida configurada, y ante empate con la de menor orden, para que la
+  // etiqueta sea estable entre recargas.
+  const salidaPorDispositivo = new Map<
+    string,
+    { salidaOrden: number | null; salidaNombre: string | null }
+  >();
+  for (const row of salidaRows) {
+    if (!paresValidos.has(`${row.dispositivoId}|${row.servicioId}`)) continue;
+    const actual = salidaPorDispositivo.get(row.dispositivoId);
+    if (
+      !actual ||
+      (actual.salidaOrden == null && row.salidaOrden != null) ||
+      (actual.salidaOrden != null &&
+        row.salidaOrden != null &&
+        row.salidaOrden < actual.salidaOrden)
+    ) {
+      salidaPorDispositivo.set(row.dispositivoId, {
+        salidaOrden: row.salidaOrden,
+        salidaNombre: row.salidaNombre,
+      });
+    }
+  }
+
+  // Calibre declarado por salida en este lote. En los datos reales hay siempre
+  // una sola fila por (lote, dispositivo), pero el modelo admite varios tramos
+  // con vigencia temporal (recalibración a mitad de lote), así que se agrupa por
+  // rango en vez de asumir fila única.
+  const calibreRows =
+    dispositivoIds.length > 0
+      ? await db
+          .select({
+            dispositivoId: loteCierreCalibreBin.dispositivoId,
+            servicioId: loteCierreCalibreBin.servicioId,
+            calibreFrom: loteCierreCalibreBin.calibreFrom,
+            calibreTo: loteCierreCalibreBin.calibreTo,
+          })
+          .from(loteCierreCalibreBin)
+          .where(
+            and(
+              eq(loteCierreCalibreBin.loteId, loteId),
+              isNotNull(loteCierreCalibreBin.dispositivoId),
+              inArray(loteCierreCalibreBin.dispositivoId, dispositivoIds)
+            )
+          )
+          .groupBy(
+            loteCierreCalibreBin.dispositivoId,
+            loteCierreCalibreBin.servicioId,
+            loteCierreCalibreBin.calibreFrom,
+            loteCierreCalibreBin.calibreTo
+          )
+          .orderBy(
+            loteCierreCalibreBin.calibreFrom,
+            loteCierreCalibreBin.calibreTo
+          )
+      : [];
+
+  const calibresPorDispositivo = new Map<string, string[]>();
+  for (const row of calibreRows) {
+    if (!row.dispositivoId) continue;
+    // Mismo criterio que la salida: solo el servicio donde el equipo contó.
+    if (!paresValidos.has(`${row.dispositivoId}|${row.servicioId}`)) continue;
+    const etiqueta = formatCalibre(row.calibreFrom, row.calibreTo);
+    if (!etiqueta) continue;
+    const acc = calibresPorDispositivo.get(row.dispositivoId);
+    if (acc) {
+      if (!acc.includes(etiqueta)) acc.push(etiqueta);
+    } else {
+      calibresPorDispositivo.set(row.dispositivoId, [etiqueta]);
+    }
+  }
+
   let hasCajas = false;
   if (servicioIds.length > 0) {
     const serviciosWithCajas = await db
@@ -172,12 +301,31 @@ export async function GET(
       totalIn: totalStats[0]?.totalIn ?? 0,
       totalOut: totalStats[0]?.totalOut ?? 0,
     },
-    devices: deviceStats.map((d) => ({
-      dispositivoNombre: d.dispositivoNombre,
-      totalIn: d.totalIn,
-      totalOut: d.totalOut,
-      lastTs: d.lastTs,
-    })),
+    // Ordenado por salida (nulls al final) igual que /api/app/dispositivos, así
+    // la tabla web y la tablet listan las salidas en el mismo orden.
+    devices: deviceStats
+      .map((d) => {
+        const salida = salidaPorDispositivo.get(d.dispositivoId);
+        return {
+          dispositivoNombre: d.dispositivoNombre,
+          salidaOrden: salida?.salidaOrden ?? null,
+          // Misma convención que /api/app/lotes/resumen-calibres: si el servicio
+          // no tiene salidas configuradas, se cae al nombre del equipo.
+          salidaLabel: salida?.salidaNombre ?? d.dispositivoNombre,
+          calibres: calibresPorDispositivo.get(d.dispositivoId) ?? [],
+          totalIn: d.totalIn,
+          totalOut: d.totalOut,
+          lastTs: d.lastTs,
+        };
+      })
+      .sort((a, b) => {
+        if (a.salidaOrden != null && b.salidaOrden != null) {
+          return a.salidaOrden - b.salidaOrden;
+        }
+        if (a.salidaOrden != null) return -1;
+        if (b.salidaOrden != null) return 1;
+        return a.dispositivoNombre.localeCompare(b.dispositivoNombre, "es");
+      }),
     hasCajas,
   });
 }

--- a/my-project/src/app/api/lotes/[loteId]/detail/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/detail/route.ts
@@ -17,12 +17,16 @@ import {
 } from "@/db/schema";
 import { eq, and, isNull, isNotNull, sql, inArray } from "drizzle-orm";
 
-// El calibre puede venir con un extremo abierto (merma: "<6", ">10"), así que
-// calibreFrom/calibreTo son nullable y hay que formatear los tres casos.
+// Un extremo abierto no es un calibre más: es la merma. Se etiqueta como tal
+// para que en la tabla se lea "merma >20" y no un rango que parezca un calibre.
+//
+// Los signos siguen a declaradoLabel() de /api/app/lotes/resumen-calibres — "<to"
+// y ">from", no "≤"/"+": el modelo no guarda si el extremo es inclusivo, así que
+// inventar "≤" afirmaría algo que el dato no dice.
 function formatCalibre(from: number | null, to: number | null): string | null {
   if (from != null && to != null) return `${from}/${to}`;
-  if (from != null) return `${from}+`;
-  if (to != null) return `≤${to}`;
+  if (from != null) return `merma >${from}`;
+  if (to != null) return `merma <${to}`;
   return null;
 }
 

--- a/my-project/src/app/api/lotes/[loteId]/detail/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/detail/route.ts
@@ -12,23 +12,14 @@ import {
   proceso,
   tipoProceso,
   dispositivo,
-  dispositivoServicio,
-  loteCierreCalibreBin,
 } from "@/db/schema";
-import { eq, and, isNull, isNotNull, sql, inArray } from "drizzle-orm";
-
-// Un extremo abierto no es un calibre más: es la merma. Se etiqueta como tal
-// para que en la tabla se lea "merma >20" y no un rango que parezca un calibre.
-//
-// Los signos siguen a declaradoLabel() de /api/app/lotes/resumen-calibres — "<to"
-// y ">from", no "≤"/"+": el modelo no guarda si el extremo es inclusivo, así que
-// inventar "≤" afirmaría algo que el dato no dice.
-function formatCalibre(from: number | null, to: number | null): string | null {
-  if (from != null && to != null) return `${from}/${to}`;
-  if (from != null) return `merma >${from}`;
-  if (to != null) return `merma <${to}`;
-  return null;
-}
+import { eq, and, isNull, sql, inArray } from "drizzle-orm";
+import {
+  claveParDispositivoServicio,
+  compararPorSalida,
+  resolverSalidasCalibre,
+  type SalidaCalibre,
+} from "@/lib/salida-calibre";
 
 export async function GET(
   request: Request,
@@ -132,23 +123,11 @@ export async function GET(
     .where(eq(loteTotalStats.loteId, loteId))
     .groupBy(loteTotalStats.dispositivoId, dispositivo.nombre);
 
-  // 7. Check if any service uses cajas
   const servicioIds = lifecycle.map((l) => l.servicioId);
 
-  // 7b. Salida física de cada dispositivo y el calibre que declaró en ESTE lote.
-  //
-  // La salida vive en dispositivo_servicio (configurable por servicio, no es una
-  // propiedad del equipo), y el calibre en lote_cierre_calibre_bin — lo escribe
-  // la tablet al cerrar el lote. Por eso el calibre se resuelve por lote y no
-  // se puede cachear como atributo de la salida: la misma salida corre calibres
-  // distintos en lotes distintos.
-  const dispositivoIds = [...new Set(deviceStats.map((d) => d.dispositivoId))];
-
-  // Pares (dispositivo, servicio) que realmente tienen conteos en este lote.
-  // Es imprescindible acotar por el par y no solo por dispositivo: un equipo
-  // suele estar vinculado a varios servicios, y solo en algunos tiene salida
-  // configurada. Filtrando solo por dispositivo, la "Salida 2" de un servicio
-  // se filtraba a lotes de otro servicio que no usa salidas.
+  // 7. Salida física de cada dispositivo y el calibre que declaró en ESTE lote.
+  // La lógica vive en @/lib/salida-calibre porque la comparte con
+  // /api/lotes/summary, que alimenta la otra página de lote.
   const paresConConteo = await db
     .selectDistinct({
       servicioId: loteTotalStats.servicioId,
@@ -157,101 +136,31 @@ export async function GET(
     .from(loteTotalStats)
     .where(eq(loteTotalStats.loteId, loteId));
 
-  const paresValidos = new Set(
-    paresConConteo.map((p) => `${p.dispositivoId}|${p.servicioId}`)
-  );
+  const salidas = await resolverSalidasCalibre(loteId, paresConConteo);
 
-  const salidaRows =
-    dispositivoIds.length > 0 && servicioIds.length > 0
-      ? await db
-          .select({
-            dispositivoId: dispositivoServicio.dispositivoId,
-            servicioId: dispositivoServicio.servicioId,
-            salidaOrden: dispositivoServicio.salidaOrden,
-            salidaNombre: dispositivoServicio.salidaNombre,
-          })
-          .from(dispositivoServicio)
-          .where(
-            and(
-              inArray(dispositivoServicio.dispositivoId, dispositivoIds),
-              inArray(dispositivoServicio.servicioId, servicioIds)
-            )
-          )
-      : [];
-
-  // Un mismo dispositivo puede tener conteos en más de un servicio del lote
-  // (raro: 1 de 270 casos en datos reales). Nos quedamos con el vínculo que sí
-  // tiene salida configurada, y ante empate con la de menor orden, para que la
-  // etiqueta sea estable entre recargas.
-  const salidaPorDispositivo = new Map<
-    string,
-    { salidaOrden: number | null; salidaNombre: string | null }
-  >();
-  for (const row of salidaRows) {
-    if (!paresValidos.has(`${row.dispositivoId}|${row.servicioId}`)) continue;
-    const actual = salidaPorDispositivo.get(row.dispositivoId);
+  // Acá las filas ya vienen sumadas por dispositivo (sin servicio), así que si un
+  // equipo contó en más de un servicio del lote (raro: 1 de 270 casos reales) hay
+  // que elegir: se prefiere el vínculo con salida configurada, y entre esos el de
+  // menor orden, para que la etiqueta sea estable entre recargas.
+  const salidaPorDispositivo = new Map<string, SalidaCalibre>();
+  for (const par of paresConConteo) {
+    const salida = salidas.get(
+      claveParDispositivoServicio(par.dispositivoId, par.servicioId)
+    );
+    if (!salida) continue;
+    const actual = salidaPorDispositivo.get(par.dispositivoId);
     if (
       !actual ||
-      (actual.salidaOrden == null && row.salidaOrden != null) ||
+      (actual.salidaOrden == null && salida.salidaOrden != null) ||
       (actual.salidaOrden != null &&
-        row.salidaOrden != null &&
-        row.salidaOrden < actual.salidaOrden)
+        salida.salidaOrden != null &&
+        salida.salidaOrden < actual.salidaOrden)
     ) {
-      salidaPorDispositivo.set(row.dispositivoId, {
-        salidaOrden: row.salidaOrden,
-        salidaNombre: row.salidaNombre,
-      });
+      salidaPorDispositivo.set(par.dispositivoId, salida);
     }
   }
 
-  // Calibre declarado por salida en este lote. En los datos reales hay siempre
-  // una sola fila por (lote, dispositivo), pero el modelo admite varios tramos
-  // con vigencia temporal (recalibración a mitad de lote), así que se agrupa por
-  // rango en vez de asumir fila única.
-  const calibreRows =
-    dispositivoIds.length > 0
-      ? await db
-          .select({
-            dispositivoId: loteCierreCalibreBin.dispositivoId,
-            servicioId: loteCierreCalibreBin.servicioId,
-            calibreFrom: loteCierreCalibreBin.calibreFrom,
-            calibreTo: loteCierreCalibreBin.calibreTo,
-          })
-          .from(loteCierreCalibreBin)
-          .where(
-            and(
-              eq(loteCierreCalibreBin.loteId, loteId),
-              isNotNull(loteCierreCalibreBin.dispositivoId),
-              inArray(loteCierreCalibreBin.dispositivoId, dispositivoIds)
-            )
-          )
-          .groupBy(
-            loteCierreCalibreBin.dispositivoId,
-            loteCierreCalibreBin.servicioId,
-            loteCierreCalibreBin.calibreFrom,
-            loteCierreCalibreBin.calibreTo
-          )
-          .orderBy(
-            loteCierreCalibreBin.calibreFrom,
-            loteCierreCalibreBin.calibreTo
-          )
-      : [];
-
-  const calibresPorDispositivo = new Map<string, string[]>();
-  for (const row of calibreRows) {
-    if (!row.dispositivoId) continue;
-    // Mismo criterio que la salida: solo el servicio donde el equipo contó.
-    if (!paresValidos.has(`${row.dispositivoId}|${row.servicioId}`)) continue;
-    const etiqueta = formatCalibre(row.calibreFrom, row.calibreTo);
-    if (!etiqueta) continue;
-    const acc = calibresPorDispositivo.get(row.dispositivoId);
-    if (acc) {
-      if (!acc.includes(etiqueta)) acc.push(etiqueta);
-    } else {
-      calibresPorDispositivo.set(row.dispositivoId, [etiqueta]);
-    }
-  }
-
+  // 8. Check if any service uses cajas
   let hasCajas = false;
   if (servicioIds.length > 0) {
     const serviciosWithCajas = await db
@@ -316,20 +225,13 @@ export async function GET(
           // Misma convención que /api/app/lotes/resumen-calibres: si el servicio
           // no tiene salidas configuradas, se cae al nombre del equipo.
           salidaLabel: salida?.salidaNombre ?? d.dispositivoNombre,
-          calibres: calibresPorDispositivo.get(d.dispositivoId) ?? [],
+          calibres: salida?.calibres ?? [],
           totalIn: d.totalIn,
           totalOut: d.totalOut,
           lastTs: d.lastTs,
         };
       })
-      .sort((a, b) => {
-        if (a.salidaOrden != null && b.salidaOrden != null) {
-          return a.salidaOrden - b.salidaOrden;
-        }
-        if (a.salidaOrden != null) return -1;
-        if (b.salidaOrden != null) return 1;
-        return a.dispositivoNombre.localeCompare(b.dispositivoNombre, "es");
-      }),
+      .sort(compararPorSalida),
     hasCajas,
   });
 }

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -7,6 +7,7 @@ import {
   claveParDispositivoServicio,
   compararPorSalida,
   resolverSalidasCalibre,
+  salidasConfiguradas,
 } from "@/lib/salida-calibre";
 
 export async function GET(request: Request) {
@@ -44,28 +45,55 @@ export async function GET(request: Request) {
     }))
   );
 
-  const result = rows
-    .map((r) => {
-      const salida = salidas.get(
-        claveParDispositivoServicio(r.dispositivoId, r.servicioId)
-      );
-      return {
-        dispositivo: r.dispositivoNombre,
-        dispositivoNombre: r.dispositivoNombre,
-        servicioId: r.servicioId,
-        salidaOrden: salida?.salidaOrden ?? null,
-        // Si el servicio no tiene salidas configuradas se cae al nombre del
-        // equipo, misma convención que /api/app/lotes/resumen-calibres.
-        salidaLabel: salida?.salidaNombre ?? r.dispositivoNombre,
-        calibres: salida?.calibres ?? [],
-        countIn: r.countIn,
-        countOut: r.countOut,
-        lastTimestamp: r.lastTimestamp
-          ? new Date(r.lastTimestamp).toISOString()
-          : null,
-      };
-    })
-    .sort(compararPorSalida);
+  const conConteos = rows.map((r) => {
+    const salida = salidas.get(
+      claveParDispositivoServicio(r.dispositivoId, r.servicioId)
+    );
+    return {
+      dispositivo: r.dispositivoNombre,
+      dispositivoNombre: r.dispositivoNombre,
+      servicioId: r.servicioId,
+      salidaOrden: salida?.salidaOrden ?? null,
+      // Si el servicio no tiene salidas configuradas se cae al nombre del
+      // equipo, misma convención que /api/app/lotes/resumen-calibres.
+      salidaLabel: salida?.salidaNombre ?? r.dispositivoNombre,
+      calibres: salida?.calibres ?? [],
+      countIn: r.countIn,
+      countOut: r.countOut,
+      lastTimestamp: r.lastTimestamp
+        ? new Date(r.lastTimestamp).toISOString()
+        : null,
+    };
+  });
+
+  // Una salida configurada que no contó nada en el lote no tiene fila en
+  // lote_total_stats y desaparecía de la tabla. Se agrega en 0: que una salida
+  // del calibrador no haya sacado nada es información, no ausencia de dato.
+  const yaListados = new Set(
+    rows.map((r) => claveParDispositivoServicio(r.dispositivoId, r.servicioId))
+  );
+  const servicioIds = [...new Set(rows.map((r) => r.servicioId))];
+  const enCero = (await salidasConfiguradas(servicioIds))
+    .filter(
+      (s) =>
+        !yaListados.has(
+          claveParDispositivoServicio(s.dispositivoId, s.servicioId)
+        )
+    )
+    .map((s) => ({
+      dispositivo: s.dispositivoNombre,
+      dispositivoNombre: s.dispositivoNombre,
+      servicioId: s.servicioId,
+      salidaOrden: s.salidaOrden,
+      salidaLabel: s.salidaNombre ?? s.dispositivoNombre,
+      // Sin conteos no se infiere merma: la salida simplemente no participó.
+      calibres: [] as string[],
+      countIn: 0,
+      countOut: 0,
+      lastTimestamp: null,
+    }));
+
+  const result = [...conConteos, ...enCero].sort(compararPorSalida);
 
   return NextResponse.json(result);
 }

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -3,6 +3,11 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { loteTotalStats, dispositivo } from "@/db/schema";
 import { eq, sql } from "drizzle-orm";
+import {
+  claveParDispositivoServicio,
+  compararPorSalida,
+  resolverSalidasCalibre,
+} from "@/lib/salida-calibre";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -13,6 +18,7 @@ export async function GET(request: Request) {
 
   const rows = await db
     .select({
+      dispositivoId: loteTotalStats.dispositivoId,
       dispositivoNombre: dispositivo.nombre,
       servicioId: loteTotalStats.servicioId,
       countIn: sql<number>`SUM(${loteTotalStats.countIn})::int`,
@@ -22,15 +28,44 @@ export async function GET(request: Request) {
     .from(loteTotalStats)
     .innerJoin(dispositivo, eq(dispositivo.id, loteTotalStats.dispositivoId))
     .where(eq(loteTotalStats.loteId, loteId))
-    .groupBy(dispositivo.nombre, loteTotalStats.servicioId);
+    .groupBy(
+      loteTotalStats.dispositivoId,
+      dispositivo.nombre,
+      loteTotalStats.servicioId
+    );
 
-  const result = rows.map((r) => ({
-    dispositivo: r.dispositivoNombre,
-    servicioId: r.servicioId,
-    countIn: r.countIn,
-    countOut: r.countOut,
-    lastTimestamp: r.lastTimestamp ? new Date(r.lastTimestamp).toISOString() : null,
-  }));
+  // Las filas ya vienen por (dispositivo, servicio), así que la salida se
+  // resuelve exacta para cada una — sin cruces entre servicios.
+  const salidas = await resolverSalidasCalibre(
+    loteId,
+    rows.map((r) => ({
+      dispositivoId: r.dispositivoId,
+      servicioId: r.servicioId,
+    }))
+  );
+
+  const result = rows
+    .map((r) => {
+      const salida = salidas.get(
+        claveParDispositivoServicio(r.dispositivoId, r.servicioId)
+      );
+      return {
+        dispositivo: r.dispositivoNombre,
+        dispositivoNombre: r.dispositivoNombre,
+        servicioId: r.servicioId,
+        salidaOrden: salida?.salidaOrden ?? null,
+        // Si el servicio no tiene salidas configuradas se cae al nombre del
+        // equipo, misma convención que /api/app/lotes/resumen-calibres.
+        salidaLabel: salida?.salidaNombre ?? r.dispositivoNombre,
+        calibres: salida?.calibres ?? [],
+        countIn: r.countIn,
+        countOut: r.countOut,
+        lastTimestamp: r.lastTimestamp
+          ? new Date(r.lastTimestamp).toISOString()
+          : null,
+      };
+    })
+    .sort(compararPorSalida);
 
   return NextResponse.json(result);
 }

--- a/my-project/src/app/app/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/lotes/[loteId]/page.tsx
@@ -29,6 +29,11 @@ interface ActiveSession {
 
 interface DeviceStats {
   dispositivoNombre: string;
+  salidaOrden: number | null;
+  salidaLabel: string;
+  // Calibre declarado por esta salida en este lote. Normalmente uno, pero el
+  // modelo admite varios tramos si se recalibra a mitad de proceso.
+  calibres: string[];
   totalIn: number;
   totalOut: number;
   lastTs: string | null;
@@ -475,13 +480,17 @@ export default function LoteGlobalDetailPage() {
                     <thead>
                       <tr className="border-b border-white/10 text-slate-400">
                         <th className="text-left py-2 pr-4 font-medium">
-                          Dispositivo
+                          Salida
+                        </th>
+                        {/* "Entradas"/"Salidas" se renombran a "Bulbos …": con la
+                            primera columna mostrando la salida física, una columna
+                            llamada "Salidas" que en realidad son conteos out se
+                            leía como si fuera lo mismo. */}
+                        <th className="text-right py-2 pr-4 font-medium">
+                          Bulbos entrada
                         </th>
                         <th className="text-right py-2 pr-4 font-medium">
-                          Entradas
-                        </th>
-                        <th className="text-right py-2 pr-4 font-medium">
-                          Salidas
+                          Bulbos salida
                         </th>
                         <th className="text-right py-2 font-medium">
                           Ultima actividad
@@ -492,7 +501,17 @@ export default function LoteGlobalDetailPage() {
                       {detail.devices.map((d) => (
                         <tr key={d.dispositivoNombre} className="text-white">
                           <td className="py-2.5 pr-4 font-medium">
-                            {d.dispositivoNombre}
+                            {/* El nombre del equipo queda en el title: sigue siendo
+                                el dato que se necesita para ir a buscarlo a terreno. */}
+                            <span title={d.dispositivoNombre}>
+                              {d.salidaLabel}
+                            </span>
+                            {d.calibres.length > 0 && (
+                              <span className="text-slate-400 font-normal">
+                                {" "}
+                                ({d.calibres.join(", ")})
+                              </span>
+                            )}
                           </td>
                           <td className="py-2.5 pr-4 text-right text-green-400">
                             {formatNumber(d.totalIn)}

--- a/my-project/src/app/app/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/lotes/[loteId]/page.tsx
@@ -17,7 +17,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ArrowLeft } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ArrowLeft, Cpu } from "lucide-react";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -475,6 +481,7 @@ export default function LoteGlobalDetailPage() {
                   Sin datos de dispositivos.
                 </p>
               ) : (
+                <TooltipProvider delayDuration={150}>
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
@@ -501,17 +508,37 @@ export default function LoteGlobalDetailPage() {
                       {detail.devices.map((d) => (
                         <tr key={d.dispositivoNombre} className="text-white">
                           <td className="py-2.5 pr-4 font-medium">
-                            {/* El nombre del equipo queda en el title: sigue siendo
-                                el dato que se necesita para ir a buscarlo a terreno. */}
-                            <span title={d.dispositivoNombre}>
+                            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
                               {d.salidaLabel}
+                              {d.calibres.length > 0 && (
+                                <span className="text-slate-400 font-normal">
+                                  ({d.calibres.join(", ")})
+                                </span>
+                              )}
+                              {/* Mismo criterio que la tabla de
+                                  /app/servicios/[id]/lotes/[id]: el icono da el
+                                  indicio de que hay algo que ver al pasar el mouse,
+                                  y se omite cuando la etiqueta ya ES el equipo. */}
+                              {d.salidaLabel !== d.dispositivoNombre && (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      type="button"
+                                      aria-label={`Dispositivo: ${d.dispositivoNombre}`}
+                                      className="text-slate-500 hover:text-slate-300 transition-colors cursor-help"
+                                    >
+                                      <Cpu className="w-3.5 h-3.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent
+                                    side="top"
+                                    className="max-w-xs bg-slate-950 text-slate-100 border border-white/10"
+                                  >
+                                    {d.dispositivoNombre}
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
                             </span>
-                            {d.calibres.length > 0 && (
-                              <span className="text-slate-400 font-normal">
-                                {" "}
-                                ({d.calibres.join(", ")})
-                              </span>
-                            )}
                           </td>
                           <td className="py-2.5 pr-4 text-right text-green-400">
                             {formatNumber(d.totalIn)}
@@ -529,6 +556,7 @@ export default function LoteGlobalDetailPage() {
                     </tbody>
                   </table>
                 </div>
+                </TooltipProvider>
               )}
 
               {/* Active sessions */}

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -14,10 +14,17 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   ScanLine,
   Sprout,
   ShieldCheck,
   Activity,
+  Cpu,
 } from "lucide-react";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -379,6 +386,7 @@ export default function LoteDetailPage() {
               ) : !summary || summary.length === 0 ? (
                 <p className="text-sm text-slate-500">Sin datos de dispositivos.</p>
               ) : (
+                <TooltipProvider delayDuration={150}>
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
@@ -402,15 +410,42 @@ export default function LoteDetailPage() {
                       {summary.map((d) => (
                         <tr key={d.dispositivo} className="text-white">
                           <td className="py-2.5 pr-4 font-medium">
-                            {/* El nombre del equipo queda en el title: sigue siendo
-                                el dato para ir a buscarlo a terreno. */}
-                            <span title={d.dispositivo}>{d.salidaLabel}</span>
-                            {d.calibres.length > 0 && (
-                              <span className="text-slate-400 font-normal">
-                                {" "}
-                                ({d.calibres.join(", ")})
-                              </span>
-                            )}
+                            <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+                              {d.salidaLabel}
+                              {d.calibres.length > 0 && (
+                                <span className="text-slate-400 font-normal">
+                                  ({d.calibres.join(", ")})
+                                </span>
+                              )}
+                              {/* El equipo sigue siendo el dato para ir a buscarlo
+                                  a terreno, pero ya no es el titulo de la fila. El
+                                  icono existe para que se vea que hay algo debajo:
+                                  en un title puro no hay nada que invite a pasar
+                                  el mouse. Se omite cuando la etiqueta ya ES el
+                                  nombre del equipo (servicio sin salidas). */}
+                              {d.salidaLabel !== d.dispositivo && (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      type="button"
+                                      aria-label={`Dispositivo: ${d.dispositivo}`}
+                                      className="text-slate-500 hover:text-slate-300 transition-colors cursor-help"
+                                    >
+                                      <Cpu className="w-3.5 h-3.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  {/* Arriba y no a la derecha: la columna es
+                                      angosta y el tooltip tapaba el numero de
+                                      "Bulbos entrada" de la misma fila. */}
+                                  <TooltipContent
+                                    side="top"
+                                    className="max-w-xs bg-slate-950 text-slate-100 border border-white/10"
+                                  >
+                                    {d.dispositivo}
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
+                            </span>
                           </td>
                           <td className="py-2.5 pr-4 text-right text-green-400">
                             {d.countIn.toLocaleString("es-CL")}
@@ -428,6 +463,7 @@ export default function LoteDetailPage() {
                     </tbody>
                   </table>
                 </div>
+                </TooltipProvider>
               )}
             </CardContent>
           </Card>

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -33,6 +33,11 @@ interface Lote {
 
 interface DeviceSummary {
   dispositivo: string;
+  salidaOrden: number | null;
+  salidaLabel: string;
+  // Calibre declarado por esta salida en este lote. Normalmente uno, pero el
+  // modelo admite varios tramos si se recalibra a mitad de proceso.
+  calibres: string[];
   countIn: number;
   countOut: number;
   lastTimestamp: string | null;
@@ -379,17 +384,34 @@ export default function LoteDetailPage() {
                     <thead>
                       <tr className="border-b border-white/10 text-slate-400">
                         <th className="text-left py-2 pr-4 font-medium">
-                          Dispositivo
+                          Salida
                         </th>
-                        <th className="text-right py-2 pr-4 font-medium">Entradas</th>
-                        <th className="text-right py-2 pr-4 font-medium">Salidas</th>
+                        {/* "Entradas"/"Salidas" pasan a "Bulbos …": con la salida
+                            física en la primera columna, una columna "Salidas"
+                            que en realidad son conteos out se confundía. */}
+                        <th className="text-right py-2 pr-4 font-medium">
+                          Bulbos entrada
+                        </th>
+                        <th className="text-right py-2 pr-4 font-medium">
+                          Bulbos salida
+                        </th>
                         <th className="text-right py-2 font-medium">Última actividad</th>
                       </tr>
                     </thead>
                     <tbody className="divide-y divide-white/5">
                       {summary.map((d) => (
                         <tr key={d.dispositivo} className="text-white">
-                          <td className="py-2.5 pr-4 font-medium">{d.dispositivo}</td>
+                          <td className="py-2.5 pr-4 font-medium">
+                            {/* El nombre del equipo queda en el title: sigue siendo
+                                el dato para ir a buscarlo a terreno. */}
+                            <span title={d.dispositivo}>{d.salidaLabel}</span>
+                            {d.calibres.length > 0 && (
+                              <span className="text-slate-400 font-normal">
+                                {" "}
+                                ({d.calibres.join(", ")})
+                              </span>
+                            )}
+                          </td>
                           <td className="py-2.5 pr-4 text-right text-green-400">
                             {d.countIn.toLocaleString("es-CL")}
                           </td>

--- a/my-project/src/emails/ServiceReportEmail.tsx
+++ b/my-project/src/emails/ServiceReportEmail.tsx
@@ -22,6 +22,76 @@ interface ServiceReportEmailProps {
 
 const font = "Arial, Helvetica, sans-serif";
 
+const num = (value: number) => value.toLocaleString("es-CL");
+const pct = (value: number) => `${value.toLocaleString("es-CL")}%`;
+
+const cell: React.CSSProperties = {
+  fontSize: 12,
+  padding: "7px 8px",
+  borderBottom: "1px solid #E2E8F0",
+  textAlign: "left",
+};
+const cellNum: React.CSSProperties = { ...cell, textAlign: "right" };
+const th: React.CSSProperties = {
+  ...cell,
+  fontSize: 10,
+  letterSpacing: 0.6,
+  color: "#64748B",
+  borderBottom: "2px solid #0E7490",
+  textTransform: "uppercase",
+};
+
+/**
+ * Detalle por calibre y, debajo de cada uno, el aporte de cada salida.
+ *
+ * Se arma con una <table> y estilos inline a proposito: los clientes de correo
+ * no soportan flex ni grid de forma confiable. Las salidas van como filas hijas
+ * en vez de columnas para que la tabla siga siendo legible en un celular.
+ */
+function CalibreTable({ report }: { report: ServiceReport }) {
+  if (report.rows.length === 0) {
+    return (
+      <Text style={{ color: "#94A3B8", fontSize: 12, margin: "0 0 8px" }}>
+        Sin datos para el periodo / No data for this period.
+      </Text>
+    );
+  }
+
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", margin: "0 0 6px" }}>
+      <thead>
+        <tr>
+          <th style={th}>Calibre / Size</th>
+          <th style={{ ...th, textAlign: "right" }}>Bulbos</th>
+          <th style={{ ...th, textAlign: "right" }}>%</th>
+          <th style={{ ...th, textAlign: "right" }}>Bins</th>
+        </tr>
+      </thead>
+      <tbody>
+        {report.rows.map((row) => [
+          <tr key={row.key}>
+            <td style={{ ...cell, fontWeight: 700 }}>{row.label}</td>
+            <td style={{ ...cellNum, fontWeight: 700 }}>{num(row.bulbs)}</td>
+            <td style={cellNum}>{pct(row.percent)}</td>
+            <td style={cellNum}>{row.bins ? num(row.bins) : "-"}</td>
+          </tr>,
+          ...row.salidas.map((salida) => (
+            <tr key={`${row.key}:${salida.dispositivoNombre}`}>
+              <td style={{ ...cell, paddingLeft: 22, color: "#475569" }}>
+                {salida.label}
+                <span style={{ color: "#94A3B8" }}> · {salida.dispositivoNombre}</span>
+              </td>
+              <td style={{ ...cellNum, color: "#475569" }}>{num(salida.bulbs)}</td>
+              <td style={{ ...cellNum, color: "#94A3B8" }}>{pct(salida.percent)}</td>
+              <td style={cellNum}>-</td>
+            </tr>
+          )),
+        ])}
+      </tbody>
+    </table>
+  );
+}
+
 export default function ServiceReportEmail({ daily, total, recipientName }: ServiceReportEmailProps) {
   return (
     <Html>
@@ -59,6 +129,23 @@ export default function ServiceReportEmail({ daily, total, recipientName }: Serv
                 </Section>
               </Column>
             </Row>
+            <Hr style={{ borderColor: "#E2E8F0", margin: "24px 0" }} />
+
+            <Text style={{ color: "#172033", fontSize: 14, fontWeight: 700, margin: "0 0 2px" }}>
+              Detalle del dia / Daily detail
+            </Text>
+            <Text style={{ color: "#94A3B8", fontSize: 11, margin: "0 0 10px" }}>
+              {daily.calibreSource === "declarado"
+                ? "Por calibre y salida. El % de cada salida es su peso dentro del calibre / By size and outlet. Each outlet's % is its share within the size."
+                : "Por calibre medido / By measured size."}
+            </Text>
+            <CalibreTable report={daily} />
+
+            <Text style={{ color: "#172033", fontSize: 14, fontWeight: 700, margin: "22px 0 10px" }}>
+              Acumulado del servicio / Service total
+            </Text>
+            <CalibreTable report={total} />
+
             <Hr style={{ borderColor: "#E2E8F0", margin: "24px 0" }} />
             <Text style={{ color: "#475569", fontSize: 13, lineHeight: "20px" }}>
               {daily.calibreSource === "declarado"

--- a/my-project/src/lib/reporting/data.ts
+++ b/my-project/src/lib/reporting/data.ts
@@ -2,6 +2,8 @@ import { and, asc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
   conteo,
+  dispositivo,
+  dispositivoServicio,
   empresa,
   lote,
   loteCierreCalibreBin,
@@ -17,6 +19,7 @@ import type {
   ReportCalibreRow,
   ReportKind,
   ReportLote,
+  ReportSalidaRow,
   ServiceReport,
 } from "./types";
 
@@ -200,8 +203,26 @@ function buildLote(
       .map((bucket) => ({
         ...bucket,
         percent: roundedPercent(bucket.bulbs, bulbs),
+        // En modo medido el calibre viene del perímetro, no de lo que declara
+        // una salida, así que no hay desglose que mostrar.
+        salidas: [],
       })),
   };
+}
+
+/** Ordena las salidas y calcula su peso dentro del calibre al que pertenecen. */
+function finishSalidas(salidas: ReportSalidaRow[], bulbsDelCalibre: number) {
+  return [...salidas]
+    .sort(
+      (left, right) =>
+        (left.salidaOrden ?? Number.POSITIVE_INFINITY) -
+          (right.salidaOrden ?? Number.POSITIVE_INFINITY) ||
+        left.label.localeCompare(right.label, "es")
+    )
+    .map((salida) => ({
+      ...salida,
+      percent: roundedPercent(salida.bulbs, bulbsDelCalibre),
+    }));
 }
 
 function mergeServiceRows(lotes: ReportLote[]) {
@@ -212,15 +233,31 @@ function mergeServiceRows(lotes: ReportLote[]) {
       if (existing) {
         existing.bulbs += row.bulbs;
         existing.bins += row.bins;
+        // Las salidas también se suman entre lotes: en el resumen del servicio
+        // "Salida 2" es el aporte de esa salida a ese calibre en todos los lotes.
+        for (const salida of row.salidas) {
+          const previa = existing.salidas.find(
+            (s) => s.dispositivoNombre === salida.dispositivoNombre
+          );
+          if (previa) previa.bulbs += salida.bulbs;
+          else existing.salidas.push({ ...salida });
+        }
       } else {
-        buckets.set(row.key, { ...row });
+        buckets.set(row.key, {
+          ...row,
+          salidas: row.salidas.map((salida) => ({ ...salida })),
+        });
       }
     }
   }
   const total = lotes.reduce((sum, current) => sum + current.bulbs, 0);
   return [...buckets.values()]
     .sort(sortCalibreRows)
-    .map((row) => ({ ...row, percent: roundedPercent(row.bulbs, total) }));
+    .map((row) => ({
+      ...row,
+      percent: roundedPercent(row.bulbs, total),
+      salidas: finishSalidas(row.salidas, row.bulbs),
+    }));
 }
 
 function declaredLabel(from: number | null, to: number | null, sinDeclarar: boolean) {
@@ -241,14 +278,57 @@ async function buildDeclaredServiceReport(metadata: { serviceName: string; compa
   const declarations = await db.select({ loteId: loteCierreCalibreBin.loteId, from: loteCierreCalibreBin.calibreFrom, to: loteCierreCalibreBin.calibreTo, bins: loteCierreCalibreBin.bins }).from(loteCierreCalibreBin).where(and(eq(loteCierreCalibreBin.servicioId, serviceId), inArray(loteCierreCalibreBin.loteId, usedLoteIds), isNotNull(loteCierreCalibreBin.dispositivoId)));
   const bins = new Map<string, number>();
   for (const row of declarations) { const key = `${row.loteId}:${row.from ?? ""}:${row.to ?? ""}`; bins.set(key, (bins.get(key) ?? 0) + (Number(row.bins) || 0)); }
+  // Etiqueta de cada salida del servicio. Se resuelve una vez y no por fila:
+  // la salida es configuración del servicio, no del lote ni del día.
+  const salidaRows = await db
+    .select({
+      dispositivoId: dispositivoServicio.dispositivoId,
+      dispositivoNombre: dispositivo.nombre,
+      salidaOrden: dispositivoServicio.salidaOrden,
+      salidaNombre: dispositivoServicio.salidaNombre,
+    })
+    .from(dispositivoServicio)
+    .innerJoin(dispositivo, eq(dispositivo.id, dispositivoServicio.dispositivoId))
+    .where(eq(dispositivoServicio.servicioId, serviceId));
+  const salidaPorDispositivo = new Map(
+    salidaRows.map((row) => [
+      row.dispositivoId,
+      {
+        salidaOrden: row.salidaOrden,
+        // Misma convención que el resto: sin salida configurada se cae al
+        // nombre del equipo en vez de mostrar un hueco.
+        label: row.salidaNombre ?? row.dispositivoNombre,
+        dispositivoNombre: row.dispositivoNombre,
+      },
+    ])
+  );
+
   const byLote = new Map<string, Map<string, ReportCalibreRow>>();
   for (const row of summary) {
     const key = row.sinDeclarar ? "sin_declarar" : `${row.calibreFrom ?? ""}:${row.calibreTo ?? ""}`;
     const rows = byLote.get(row.loteId) ?? new Map<string, ReportCalibreRow>();
-    const current = rows.get(key) ?? { key, label: declaredLabel(row.calibreFrom, row.calibreTo, row.sinDeclarar), bulbs: 0, bins: row.sinDeclarar ? 0 : bins.get(`${row.loteId}:${row.calibreFrom ?? ""}:${row.calibreTo ?? ""}`) ?? 0, percent: 0 };
-    current.bulbs += Number(row.unidades) || 0; rows.set(key, current); byLote.set(row.loteId, rows);
+    const current = rows.get(key) ?? { key, label: declaredLabel(row.calibreFrom, row.calibreTo, row.sinDeclarar), bulbs: 0, bins: row.sinDeclarar ? 0 : bins.get(`${row.loteId}:${row.calibreFrom ?? ""}:${row.calibreTo ?? ""}`) ?? 0, percent: 0, salidas: [] };
+    current.bulbs += Number(row.unidades) || 0;
+    // El resumen ya viene por (dia, lote, servicio, dispositivo, calibre), así
+    // que cada fila es el aporte de una salida a este rango de calibre. En el
+    // reporte total hay varias filas por salida (una por día) y se acumulan.
+    const unidades = Number(row.unidades) || 0;
+    const salida = salidaPorDispositivo.get(row.dispositivoId);
+    const existente = current.salidas.find((s) => s.dispositivoNombre === (salida?.dispositivoNombre ?? row.dispositivoId));
+    if (existente) {
+      existente.bulbs += unidades;
+    } else {
+      current.salidas.push({
+        salidaOrden: salida?.salidaOrden ?? null,
+        label: salida?.label ?? row.dispositivoId.slice(0, 8),
+        dispositivoNombre: salida?.dispositivoNombre ?? row.dispositivoId.slice(0, 8),
+        bulbs: unidades,
+        percent: 0,
+      });
+    }
+    rows.set(key, current); byLote.set(row.loteId, rows);
   }
-  const lotes = [...byLote.entries()].map(([loteId, rows]) => { const values = [...rows.values()].sort(sortCalibreRows); const bulbs = values.reduce((sum, row) => sum + row.bulbs, 0); return { loteId, codigoLote: nameMap.get(loteId) ?? loteId.slice(0, 8), bulbs, percent: 0, rows: values.map((row) => ({ ...row, percent: roundedPercent(row.bulbs, bulbs) })) }; }).sort((a, b) => a.codigoLote.localeCompare(b.codigoLote, "es"));
+  const lotes = [...byLote.entries()].map(([loteId, rows]) => { const values = [...rows.values()].sort(sortCalibreRows); const bulbs = values.reduce((sum, row) => sum + row.bulbs, 0); return { loteId, codigoLote: nameMap.get(loteId) ?? loteId.slice(0, 8), bulbs, percent: 0, rows: values.map((row) => ({ ...row, percent: roundedPercent(row.bulbs, bulbs), salidas: finishSalidas(row.salidas, row.bulbs) })) }; }).sort((a, b) => a.codigoLote.localeCompare(b.codigoLote, "es"));
   const totalBulbs = lotes.reduce((sum, row) => sum + row.bulbs, 0); for (const row of lotes) row.percent = roundedPercent(row.bulbs, totalBulbs);
   return { kind, serviceId, serviceName: metadata.serviceName, companyName: metadata.companyName, processName: metadata.processName, reportDate, generatedAt: new Date().toISOString(), calibreSource: "declarado", totalBulbs, rows: mergeServiceRows(lotes), lotes };
 }

--- a/my-project/src/lib/reporting/pdf.tsx
+++ b/my-project/src/lib/reporting/pdf.tsx
@@ -40,6 +40,10 @@ const styles = StyleSheet.create({
   tableRow: { flexDirection: "row", paddingVertical: 5, paddingHorizontal: 7, borderTopWidth: 1, borderTopColor: colors.line, backgroundColor: colors.white },
   tableRowAlt: { backgroundColor: colors.soft },
   colLabel: { width: "46%" },
+  // Fila hija de una salida: sin borde propio y con sangria, para que se lea
+  // colgando del calibre de arriba y no como otro calibre.
+  salidaRow: { borderTopWidth: 0, paddingVertical: 3 },
+  colSalidaLabel: { width: "46%", paddingLeft: 10, color: colors.muted, fontSize: 8 },
   colBulbs: { width: "18%", textAlign: "right" },
   colPercent: { width: "18%", textAlign: "right" },
   colBins: { width: "18%", textAlign: "right" },
@@ -170,12 +174,30 @@ export function ServiceReportDocument({ report }: { report: ServiceReport }): Re
                 <Text style={styles.colLabel}>Calibre / Size</Text><Text style={styles.colBulbs}>Bulbos</Text><Text style={styles.colPercent}>%</Text><Text style={styles.colBins}>Bins</Text>
               </View>
               {report.rows.map((row, index) => (
-                <View key={row.key} style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}]} wrap={false}>
-                  <Text style={styles.colLabel}>{row.label}</Text>
-                  <Text style={styles.colBulbs}>{number(row.bulbs)}</Text>
-                  <Text style={styles.colPercent}>{number(row.percent)}%</Text>
-                  <Text style={styles.colBins}>{row.bins ? number(row.bins) : "-"}</Text>
-                </View>
+                <React.Fragment key={row.key}>
+                  <View style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}]} wrap={false}>
+                    <Text style={styles.colLabel}>{row.label}</Text>
+                    <Text style={styles.colBulbs}>{number(row.bulbs)}</Text>
+                    <Text style={styles.colPercent}>{number(row.percent)}%</Text>
+                    <Text style={styles.colBins}>{row.bins ? number(row.bins) : "-"}</Text>
+                  </View>
+                  {/* Aporte de cada salida al calibre de arriba. El % es dentro
+                      del calibre, no sobre el total del reporte. */}
+                  {row.salidas.map((salida) => (
+                    <View
+                      key={`${row.key}-${salida.dispositivoNombre}`}
+                      style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}, styles.salidaRow]}
+                      wrap={false}
+                    >
+                      <Text style={styles.colSalidaLabel}>
+                        {salida.label} · {salida.dispositivoNombre}
+                      </Text>
+                      <Text style={styles.colBulbs}>{number(salida.bulbs)}</Text>
+                      <Text style={styles.colPercent}>{number(salida.percent)}%</Text>
+                      <Text style={styles.colBins}>-</Text>
+                    </View>
+                  ))}
+                </React.Fragment>
               ))}
             </View>
           </>

--- a/my-project/src/lib/reporting/types.ts
+++ b/my-project/src/lib/reporting/types.ts
@@ -1,11 +1,31 @@
 export type ReportKind = "daily" | "total";
 
+/**
+ * Aporte de una salida física del calibrador dentro de un rango de calibre.
+ *
+ * Solo se puebla en servicios con modoCalibre 'declarado' y con salidas
+ * configuradas en dispositivo_servicio; en modo medido queda vacío, porque ahí
+ * el calibre sale del perímetro y no de lo que declara una salida.
+ */
+export interface ReportSalidaRow {
+  /** salida_orden, para ordenar. Null si el equipo no tiene salida configurada. */
+  salidaOrden: number | null;
+  /** "Salida 2", o el nombre del equipo si el servicio no usa salidas. */
+  label: string;
+  /** Nombre del dispositivo, para poder rastrearlo en terreno. */
+  dispositivoNombre: string;
+  bulbs: number;
+  percent: number;
+}
+
 export interface ReportCalibreRow {
   key: string;
   label: string;
   bulbs: number;
   bins: number;
   percent: number;
+  /** Desglose por salida dentro de este calibre. Vacío en modo medido. */
+  salidas: ReportSalidaRow[];
 }
 
 export interface ReportLote {

--- a/my-project/src/lib/reporting/xlsx.ts
+++ b/my-project/src/lib/reporting/xlsx.ts
@@ -45,24 +45,41 @@ function header(report: ServiceReport, title: string): Cell[][] {
  * la columna repetida. Se prefiere esto a `!merges` porque una celda combinada
  * rompe el ordenar y el filtrar sobre la tabla.
  */
-function detailRows(report: ServiceReport): Cell[][] {
-  const rows: Cell[][] = [["Lote / Lot", "Calibre / Size", "Bulbos", "%", "Bins"]];
+function detailRows(report: ServiceReport, withSalidas: boolean): Cell[][] {
+  const head: Cell[] = withSalidas
+    ? ["Lote / Lot", "Calibre / Size", "Salida / Outlet", "Bulbos", "%", "Bins"]
+    : ["Lote / Lot", "Calibre / Size", "Bulbos", "%", "Bins"];
+  const rows: Cell[][] = [head];
   for (const lote of report.lotes) {
     if (lote.rows.length === 0) {
-      rows.push([lote.codigoLote, "Sin datos para el periodo", null, null, null]);
+      rows.push(
+        withSalidas
+          ? [lote.codigoLote, "Sin datos para el periodo", null, null, null, null]
+          : [lote.codigoLote, "Sin datos para el periodo", null, null, null]
+      );
       rows.push([]);
       continue;
     }
     lote.rows.forEach((row, index) => {
-      rows.push([
-        index === 0 ? lote.codigoLote : null,
-        row.label,
-        row.bulbs,
-        row.percent,
-        row.bins || null,
-      ]);
+      const codigo = index === 0 ? lote.codigoLote : null;
+      rows.push(
+        withSalidas
+          ? [codigo, row.label, "Todas / All", row.bulbs, row.percent, row.bins || null]
+          : [codigo, row.label, row.bulbs, row.percent, row.bins || null]
+      );
+      // Una fila por salida bajo su calibre: el % es el peso de la salida dentro
+      // de ese calibre, no sobre el lote.
+      if (withSalidas) {
+        for (const salida of row.salidas) {
+          rows.push([null, null, salida.label, salida.bulbs, salida.percent, null]);
+        }
+      }
     });
-    rows.push([null, "Total lote / Lot total", lote.bulbs, lote.percent, null]);
+    rows.push(
+      withSalidas
+        ? [null, "Total lote / Lot total", null, lote.bulbs, lote.percent, null]
+        : [null, "Total lote / Lot total", lote.bulbs, lote.percent, null]
+    );
     rows.push([]);
   }
   return rows;
@@ -74,30 +91,52 @@ const PERCENT_FORMAT = '0.00"%"';
 const BULBS_FORMAT = "#,##0";
 
 function reportSheet(report: ServiceReport, title: string) {
+  // La columna de salida solo se agrega si el servicio realmente declara por
+  // salida: en modo medido estaria vacia en todas las filas.
+  const withSalidas = report.rows.some((row) => row.salidas.length > 0);
+
   const rows: Cell[][] = [
     ...header(report, title),
     ["Resumen por calibre / Size summary"],
-    ["Calibre / Size", "Bulbos", "%", "Bins"],
+    withSalidas
+      ? ["Calibre / Size", "Salida / Outlet", "Bulbos", "%", "Bins"]
+      : ["Calibre / Size", "Bulbos", "%", "Bins"],
   ];
   const summaryFrom = rows.length;
-  for (const row of report.rows) rows.push([row.label, row.bulbs, row.percent, row.bins || null]);
+  for (const row of report.rows) {
+    rows.push(
+      withSalidas
+        ? [row.label, "Todas / All", row.bulbs, row.percent, row.bins || null]
+        : [row.label, row.bulbs, row.percent, row.bins || null]
+    );
+    // El % de la salida es su peso dentro del calibre, no sobre el total.
+    if (withSalidas) {
+      for (const salida of row.salidas) {
+        rows.push([null, salida.label, salida.bulbs, salida.percent, null]);
+      }
+    }
+  }
   if (report.rows.length === 0) rows.push(["Sin datos para el periodo / No data for this period"]);
   const summaryTo = rows.length - 1;
 
   rows.push([], ["Detalle por lote / Lot detail"]);
   const detailFrom = rows.length + 1;
-  rows.push(...detailRows(report));
+  rows.push(...detailRows(report, withSalidas));
   const detailTo = rows.length - 1;
 
   const sheet = XLSX.utils.aoa_to_sheet(rows);
-  sheet["!cols"] = [{ wch: 34 }, { wch: 34 }, { wch: 16 }, { wch: 10 }, { wch: 10 }];
+  sheet["!cols"] = withSalidas
+    ? [{ wch: 34 }, { wch: 34 }, { wch: 20 }, { wch: 16 }, { wch: 10 }, { wch: 10 }]
+    : [{ wch: 34 }, { wch: 34 }, { wch: 16 }, { wch: 10 }, { wch: 10 }];
   // Las dos tablas tienen distinto orden de columnas, asi que el formato se
   // acota por bloque: en el resumen los bulbos van en B y el % en C; en el
-  // detalle, desplazados una columna por el codigo de lote.
-  formatCells(sheet, 1, summaryFrom, summaryTo, BULBS_FORMAT);
-  formatCells(sheet, 2, summaryFrom, summaryTo, PERCENT_FORMAT);
-  formatCells(sheet, 2, detailFrom, detailTo, BULBS_FORMAT);
-  formatCells(sheet, 3, detailFrom, detailTo, PERCENT_FORMAT);
+  // detalle, desplazados una columna por el codigo de lote. Con la columna de
+  // salida, ambos bloques se desplazan una columna mas.
+  const offset = withSalidas ? 1 : 0;
+  formatCells(sheet, 1 + offset, summaryFrom, summaryTo, BULBS_FORMAT);
+  formatCells(sheet, 2 + offset, summaryFrom, summaryTo, PERCENT_FORMAT);
+  formatCells(sheet, 2 + offset, detailFrom, detailTo, BULBS_FORMAT);
+  formatCells(sheet, 3 + offset, detailFrom, detailTo, PERCENT_FORMAT);
   return sheet;
 }
 

--- a/my-project/src/lib/salida-calibre.ts
+++ b/my-project/src/lib/salida-calibre.ts
@@ -1,0 +1,191 @@
+import { db } from "@/db";
+import { dispositivoServicio, loteCierreCalibreBin } from "@/db/schema";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+
+// Salida física de un calibrador y el calibre que declaró en un lote puntual.
+//
+// Vive acá y no en cada ruta porque hay dos páginas de lote (/app/lotes/[id] y
+// /app/servicios/[id]/lotes/[id]) alimentadas por endpoints distintos, y la
+// etiqueta tiene que salir igual en las dos.
+
+export interface SalidaCalibre {
+  salidaOrden: number | null;
+  salidaNombre: string | null;
+  /** Calibres declarados en el lote. Normalmente uno; varios si se recalibró. */
+  calibres: string[];
+}
+
+export interface ParDispositivoServicio {
+  dispositivoId: string;
+  servicioId: string;
+}
+
+/** Clave del mapa que devuelve `resolverSalidasCalibre`. */
+export function claveParDispositivoServicio(
+  dispositivoId: string,
+  servicioId: string
+): string {
+  return `${dispositivoId}|${servicioId}`;
+}
+
+/** Etiqueta de la salida que quedó sin calibre en un lote ya cerrado. */
+export const ETIQUETA_MERMA = "merma";
+
+// Un extremo abierto tampoco es un calibre cerrado: es merma con umbral. Se
+// etiqueta como tal para que se lea "merma >20" y no un rango que parezca un
+// calibre.
+//
+// Los signos siguen a declaradoLabel() de /api/app/lotes/resumen-calibres —
+// "<to" y ">from", no "≤"/"+": el modelo no guarda si el extremo es inclusivo,
+// así que inventar "≤" afirmaría algo que el dato no dice.
+export function formatCalibre(
+  from: number | null,
+  to: number | null
+): string | null {
+  if (from != null && to != null) return `${from}/${to}`;
+  if (from != null) return `${ETIQUETA_MERMA} >${from}`;
+  if (to != null) return `${ETIQUETA_MERMA} <${to}`;
+  return null;
+}
+
+/**
+ * Resuelve salida y calibre para pares (dispositivo, servicio) concretos.
+ *
+ * Se pide el par y no solo el dispositivo a propósito: un equipo suele estar
+ * vinculado a varios servicios y solo en algunos tiene salida configurada.
+ * Resolviendo por dispositivo, la "Salida 2" de un servicio se filtra a lotes
+ * de otro servicio que no usa salidas.
+ */
+export async function resolverSalidasCalibre(
+  loteId: string,
+  pares: ParDispositivoServicio[]
+): Promise<Map<string, SalidaCalibre>> {
+  const resultado = new Map<string, SalidaCalibre>();
+  if (pares.length === 0) return resultado;
+
+  const dispositivoIds = [...new Set(pares.map((p) => p.dispositivoId))];
+  const servicioIds = [...new Set(pares.map((p) => p.servicioId))];
+  const paresValidos = new Set(
+    pares.map((p) => claveParDispositivoServicio(p.dispositivoId, p.servicioId))
+  );
+
+  // Se siembra una entrada por par para poder distinguir después "salida sin
+  // calibre" de "salida que no existe".
+  for (const clave of paresValidos) {
+    resultado.set(clave, {
+      salidaOrden: null,
+      salidaNombre: null,
+      calibres: [],
+    });
+  }
+
+  // La salida vive en dispositivo_servicio: es configurable por servicio, no es
+  // una propiedad del equipo.
+  const salidaRows = await db
+    .select({
+      dispositivoId: dispositivoServicio.dispositivoId,
+      servicioId: dispositivoServicio.servicioId,
+      salidaOrden: dispositivoServicio.salidaOrden,
+      salidaNombre: dispositivoServicio.salidaNombre,
+    })
+    .from(dispositivoServicio)
+    .where(
+      and(
+        inArray(dispositivoServicio.dispositivoId, dispositivoIds),
+        inArray(dispositivoServicio.servicioId, servicioIds)
+      )
+    );
+
+  for (const row of salidaRows) {
+    const clave = claveParDispositivoServicio(row.dispositivoId, row.servicioId);
+    if (!paresValidos.has(clave)) continue;
+    const actual = resultado.get(clave);
+    resultado.set(clave, {
+      salidaOrden: row.salidaOrden,
+      salidaNombre: row.salidaNombre,
+      calibres: actual?.calibres ?? [],
+    });
+  }
+
+  // El calibre lo escribe la tablet al cerrar el lote. Se resuelve por lote y no
+  // se puede cachear como atributo de la salida: la misma salida corre calibres
+  // distintos en lotes distintos.
+  const calibreRows = await db
+    .select({
+      dispositivoId: loteCierreCalibreBin.dispositivoId,
+      servicioId: loteCierreCalibreBin.servicioId,
+      calibreFrom: loteCierreCalibreBin.calibreFrom,
+      calibreTo: loteCierreCalibreBin.calibreTo,
+    })
+    .from(loteCierreCalibreBin)
+    .where(
+      and(
+        eq(loteCierreCalibreBin.loteId, loteId),
+        isNotNull(loteCierreCalibreBin.dispositivoId),
+        inArray(loteCierreCalibreBin.dispositivoId, dispositivoIds)
+      )
+    )
+    .groupBy(
+      loteCierreCalibreBin.dispositivoId,
+      loteCierreCalibreBin.servicioId,
+      loteCierreCalibreBin.calibreFrom,
+      loteCierreCalibreBin.calibreTo
+    )
+    .orderBy(loteCierreCalibreBin.calibreFrom, loteCierreCalibreBin.calibreTo);
+
+  let huboDeclaracion = false;
+  for (const row of calibreRows) {
+    if (!row.dispositivoId) continue;
+    const clave = claveParDispositivoServicio(row.dispositivoId, row.servicioId);
+    if (!paresValidos.has(clave)) continue;
+    const etiqueta = formatCalibre(row.calibreFrom, row.calibreTo);
+    if (!etiqueta) continue;
+    huboDeclaracion = true;
+    const actual = resultado.get(clave);
+    if (actual) {
+      if (!actual.calibres.includes(etiqueta)) actual.calibres.push(etiqueta);
+    } else {
+      resultado.set(clave, {
+        salidaOrden: null,
+        salidaNombre: null,
+        calibres: [etiqueta],
+      });
+    }
+  }
+
+  // La merma no se declara con un rango: se deja sin declarar. En la práctica la
+  // operaria declara el calibre de cada salida que sacó producto calibrado y deja
+  // en blanco la que salió merma — no existe ninguna fila con ambos extremos
+  // nulos en la base, así que este es el único caso real de merma.
+  //
+  // Se exige que el lote tenga al menos otra salida declarada: eso confirma que
+  // el cierre ocurrió. Sin esa condición, un lote nunca cerrado (o uno donde se
+  // olvidó declarar) mostraría todas sus salidas como merma, afirmando algo que
+  // el dato no respalda.
+  if (huboDeclaracion) {
+    for (const entrada of resultado.values()) {
+      if (entrada.calibres.length === 0) {
+        entrada.calibres.push(ETIQUETA_MERMA);
+      }
+    }
+  }
+
+  return resultado;
+}
+
+/**
+ * Orden de salidas tal como lo hace /api/app/dispositivos: por salidaOrden con
+ * los nulos al final, y entre nulos por nombre. Así la tabla web y la tablet
+ * listan las salidas igual.
+ */
+export function compararPorSalida(
+  a: { salidaOrden: number | null; dispositivoNombre: string },
+  b: { salidaOrden: number | null; dispositivoNombre: string }
+): number {
+  if (a.salidaOrden != null && b.salidaOrden != null) {
+    return a.salidaOrden - b.salidaOrden;
+  }
+  if (a.salidaOrden != null) return -1;
+  if (b.salidaOrden != null) return 1;
+  return a.dispositivoNombre.localeCompare(b.dispositivoNombre, "es");
+}

--- a/my-project/src/lib/salida-calibre.ts
+++ b/my-project/src/lib/salida-calibre.ts
@@ -1,6 +1,10 @@
 import { db } from "@/db";
-import { dispositivoServicio, loteCierreCalibreBin } from "@/db/schema";
-import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import {
+  dispositivo,
+  dispositivoServicio,
+  loteCierreCalibreBin,
+} from "@/db/schema";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 
 // Salida física de un calibrador y el calibre que declaró en un lote puntual.
 //
@@ -171,6 +175,54 @@ export async function resolverSalidasCalibre(
   }
 
   return resultado;
+}
+
+export interface SalidaConfigurada {
+  dispositivoId: string;
+  dispositivoNombre: string;
+  servicioId: string;
+  salidaOrden: number;
+  salidaNombre: string | null;
+}
+
+/**
+ * Salidas que el calibrador tiene configuradas hoy en estos servicios.
+ *
+ * Sirve para listar una salida que no produjo nada en el lote: las tablas se
+ * arman desde lote_total_stats, que solo tiene filas de equipos con conteos, y
+ * sin esto una salida en cero desaparece de la tabla en vez de mostrarse en 0
+ * — que es justamente la información de que esa salida no sacó nada.
+ *
+ * Solo vínculos vigentes (fecha_termino IS NULL): la salida es la configuración
+ * actual del calibrador. Para un lote antiguo eso puede mostrar en 0 una salida
+ * que no existía entonces, pero es preferible a esconder una salida activa.
+ */
+export async function salidasConfiguradas(
+  servicioIds: string[]
+): Promise<SalidaConfigurada[]> {
+  if (servicioIds.length === 0) return [];
+  const rows = await db
+    .select({
+      dispositivoId: dispositivoServicio.dispositivoId,
+      dispositivoNombre: dispositivo.nombre,
+      servicioId: dispositivoServicio.servicioId,
+      salidaOrden: dispositivoServicio.salidaOrden,
+      salidaNombre: dispositivoServicio.salidaNombre,
+    })
+    .from(dispositivoServicio)
+    .innerJoin(dispositivo, eq(dispositivo.id, dispositivoServicio.dispositivoId))
+    .where(
+      and(
+        inArray(dispositivoServicio.servicioId, servicioIds),
+        isNull(dispositivoServicio.fechaTermino),
+        isNotNull(dispositivoServicio.salidaOrden)
+      )
+    );
+  return rows.flatMap((row) =>
+    row.salidaOrden == null
+      ? []
+      : [{ ...row, salidaOrden: row.salidaOrden }]
+  );
 }
 
 /**


### PR DESCRIPTION
Las tablas de lote y la reportería mostraban el nombre del equipo (`THOR-1`, `ORIN-AGX-2`, …). En el calibrador lo que importa es la **salida física** y el **calibre que esa salida corrió en el lote**, así que ahora se muestra `Salida 1 (12/14)` y el equipo queda a un hover de distancia.

Cierra el pendiente **F4** que estaba anotado en `data.ts`: la reportería resolvía el calibre declarado pero agregaba la salida, así que el correo afirmaba *"incluyen calibre declarado por salida"* sin que el dato la llevara.

## Qué cambia

**Tablas de lote** (las dos páginas: `/app/lotes/[id]` y `/app/servicios/[id]/lotes/[id]`)
- Primera columna pasa de `Dispositivo` a `Salida`, con el calibre entre paréntesis.
- Ícono con tooltip para ver el equipo. Es un `<button>` con `aria-label`, no un `<span title>`, así el dato también llega por teclado y lector de pantalla.
- `Entradas`/`Salidas` → `Bulbos entrada`/`Bulbos salida`: con la salida física en la primera columna, una columna llamada "Salidas" que en realidad son conteos *out* se confundía.

**Correo, Excel y PDF**
- `ReportCalibreRow` gana `salidas`: el aporte de cada salida a ese calibre, con su % **dentro del calibre** (no sobre el total).
- El correo pasa a mostrar dos tablas (día y acumulado) con las salidas como filas hijas de su calibre. Antes no mostraba ningún detalle, solo totales.
- `mergeServiceRows` suma las salidas entre lotes, así en el acumulado se ve algo que antes no: el calibre 8-10 vino 19,86% de la Salida 2 y 80,14% de la Salida 3.
- La columna `Salida / Outlet` solo se agrega si el servicio declara por salida, para no dejarla vacía en modo medido.

## Decisiones que vale la pena revisar

**El mapeo salida↔equipo no está hardcodeado.** Sale de `dispositivo_servicio.salida_orden`, que es configurable por servicio. Si el mapeo real cambia, se corrige en los datos.

**La merma se infiere, no se declara.** En la base no existe ninguna fila con ambos extremos de calibre nulos: la operaria declara el calibre de cada salida que sacó producto calibrado y **deja en blanco la que salió merma**. Por eso una salida sin calibre se rotula `merma` — pero solo si el lote tiene al menos otra salida declarada, lo que confirma que el cierre ocurrió. Sin esa condición, un lote nunca cerrado mostraría todas sus salidas como merma, afirmando algo que el dato no respalda.

**Salidas en cero.** Una salida configurada sin conteos en el lote no tiene fila en `lote_total_stats` y desaparecía de la tabla. Ahora se lista en 0: que una salida no haya sacado nada es información. No se le infiere merma — no participó, que es distinto de haber sacado descarte.

**Se resuelve por par (dispositivo, servicio), no por dispositivo.** Un equipo suele estar vinculado a varios servicios y solo en algunos tiene salida configurada. Filtrando solo por dispositivo, la "Salida 2" de un servicio se filtraba a lotes de otro servicio sin salidas (bug real, encontrado y corregido durante el desarrollo). La lógica vive en `@/lib/salida-calibre` y la comparten las dos rutas, para que no vuelva a divergir.

**Signos de rango abierto.** Se siguen los de `declaradoLabel()` — `<to` / `>from`, no `≤`/`+`: el modelo no guarda si el extremo es inclusivo.

## Verificación

- `tsc --noEmit` limpio.
- Probado en la app con datos reales: `110.25.V4` muestra `Salida 1 (merma)`, `2 (10/12)`, `3 (8/10)`, `4 (7/8)`; el lote activo muestra la Salida 4 en 0; un lote de servicio sin salidas cae al nombre del equipo y **no** se rotula merma.
- Correo, Excel y PDF generados contra la base y revisados; correo de prueba enviado y recibido.

### Sin cubrir
- **La etiqueta de merma no se pudo probar end-to-end**: no existe en la base ningún lote con conteos *y* calibre de rango abierto. Las cuatro ramas de `formatCalibre` se verificaron aisladas.
- **El reporte sigue diciendo `Sin declarar / Undeclared`**, no "merma". En la tabla del lote sí dice merma; no unifiqué la terminología en el reporte porque va a clientes.
- Para un lote antiguo, las salidas en cero se listan según la configuración **actual** del calibrador (solo vínculos con `fecha_termino IS NULL`).

### No relacionado, encontrado de paso
`/api/calibres/breakdown` devuelve **500** — `FULL JOIN is only supported with merge-joinable or hash-joinable join conditions` sobre la vista `v_lote_calibre_declarado` (`calibre-resolver.ts:81`). La pestaña **Calibres** está rota. Es preexistente y no se toca acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
