### PR TITLE
feat(lotes/reportes): cajas de entrada, bins por calibre y merma fuera del total

### DIFF
--- a/my-project/src/app/api/lotes/[loteId]/contenedores/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/contenedores/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { contenedoresDelLote } from "@/lib/lote-contenedores";
+
+// Endpoint propio en vez de agregar los campos a /api/lotes/summary: esa ruta
+// devuelve un array de dispositivos y la consumen dos vistas, asi que cambiarle
+// la forma para colgarle datos del lote las rompe a las dos. Este lo usan las
+// dos paginas de lote, para que el numero no se calcule de dos maneras.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ loteId: string }> }
+) {
+  const { loteId } = await params;
+  const contenedores = await contenedoresDelLote(loteId);
+  return NextResponse.json(contenedores);
+}

--- a/my-project/src/app/api/lotes/[loteId]/detail/route.ts
+++ b/my-project/src/app/api/lotes/[loteId]/detail/route.ts
@@ -17,6 +17,7 @@ import { eq, and, isNull, sql, inArray } from "drizzle-orm";
 import {
   claveParDispositivoServicio,
   compararPorSalida,
+  esMerma,
   resolverSalidasCalibre,
   type SalidaCalibre,
 } from "@/lib/salida-calibre";
@@ -226,6 +227,7 @@ export async function GET(
           // no tiene salidas configuradas, se cae al nombre del equipo.
           salidaLabel: salida?.salidaNombre ?? d.dispositivoNombre,
           calibres: salida?.calibres ?? [],
+          esMerma: esMerma(salida?.calibres ?? []),
           totalIn: d.totalIn,
           totalOut: d.totalOut,
           lastTs: d.lastTs,

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -6,6 +6,7 @@ import { eq, sql } from "drizzle-orm";
 import {
   claveParDispositivoServicio,
   compararPorSalida,
+  esMerma,
   resolverSalidasCalibre,
   salidasConfiguradas,
 } from "@/lib/salida-calibre";
@@ -58,6 +59,9 @@ export async function GET(request: Request) {
       // equipo, misma convención que /api/app/lotes/resumen-calibres.
       salidaLabel: salida?.salidaNombre ?? r.dispositivoNombre,
       calibres: salida?.calibres ?? [],
+      // Lo marca el backend para que el total del lote pueda excluir la merma
+      // sin que la UI tenga que reconocerla por el texto de la etiqueta.
+      esMerma: esMerma(salida?.calibres ?? []),
       countIn: r.countIn,
       countOut: r.countOut,
       lastTimestamp: r.lastTimestamp
@@ -88,6 +92,7 @@ export async function GET(request: Request) {
       salidaLabel: s.salidaNombre ?? s.dispositivoNombre,
       // Sin conteos no se infiere merma: la salida simplemente no participó.
       calibres: [] as Array<{ etiqueta: string; bins: number | null }>,
+      esMerma: false,
       countIn: 0,
       countOut: 0,
       lastTimestamp: null,

--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -87,7 +87,7 @@ export async function GET(request: Request) {
       salidaOrden: s.salidaOrden,
       salidaLabel: s.salidaNombre ?? s.dispositivoNombre,
       // Sin conteos no se infiere merma: la salida simplemente no participó.
-      calibres: [] as string[],
+      calibres: [] as Array<{ etiqueta: string; bins: number | null }>,
       countIn: 0,
       countOut: 0,
       lastTimestamp: null,

--- a/my-project/src/app/app/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/lotes/[loteId]/page.tsx
@@ -37,9 +37,10 @@ interface DeviceStats {
   dispositivoNombre: string;
   salidaOrden: number | null;
   salidaLabel: string;
-  // Calibre declarado por esta salida en este lote. Normalmente uno, pero el
-  // modelo admite varios tramos si se recalibra a mitad de proceso.
-  calibres: string[];
+  // Calibre declarado por esta salida en este lote, con los bins que sacó.
+  // Normalmente uno, pero el modelo admite varios tramos si se recalibra a
+  // mitad de proceso.
+  calibres: Array<{ etiqueta: string; bins: number | null }>;
   totalIn: number;
   totalOut: number;
   lastTs: string | null;
@@ -512,7 +513,7 @@ export default function LoteGlobalDetailPage() {
                               {d.salidaLabel}
                               {d.calibres.length > 0 && (
                                 <span className="text-slate-400 font-normal">
-                                  ({d.calibres.join(", ")})
+                                  ({d.calibres.map((c) => c.etiqueta).join(", ")})
                                 </span>
                               )}
                               {/* Mismo criterio que la tabla de

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -50,7 +50,8 @@ interface DeviceSummary {
   salidaLabel: string;
   // Calibre declarado por esta salida en este lote. Normalmente uno, pero el
   // modelo admite varios tramos si se recalibra a mitad de proceso.
-  calibres: string[];
+  /** Calibre declarado por esta salida en el lote, con sus bins. */
+  calibres: Array<{ etiqueta: string; bins: number | null }>;
   countIn: number;
   countOut: number;
   lastTimestamp: string | null;
@@ -439,6 +440,12 @@ export default function LoteDetailPage() {
                         <th className="text-right py-2 pr-4 font-medium">
                           Bulbos salida
                         </th>
+                        {/* Los bins van por fila y no solo en el total del lote:
+                            dentro de un lote cada calibre pertenece a una sola
+                            salida, asi que la fila ya identifica el rango. */}
+                        <th className="text-right py-2 pr-4 font-medium">
+                          Bins
+                        </th>
                         <th className="text-right py-2 font-medium">Última actividad</th>
                       </tr>
                     </thead>
@@ -450,7 +457,7 @@ export default function LoteDetailPage() {
                               {d.salidaLabel}
                               {d.calibres.length > 0 && (
                                 <span className="text-slate-400 font-normal">
-                                  ({d.calibres.join(", ")})
+                                  ({d.calibres.map((c) => c.etiqueta).join(", ")})
                                 </span>
                               )}
                               {/* El equipo sigue siendo el dato para ir a buscarlo
@@ -488,6 +495,17 @@ export default function LoteDetailPage() {
                           </td>
                           <td className="py-2.5 pr-4 text-right text-red-400">
                             {d.countOut.toLocaleString("es-CL")}
+                          </td>
+                          <td className="py-2.5 pr-4 text-right text-orange-300">
+                            {/* Un guion y no un 0: la merma no declara bins, y un
+                                lote sin cerrar tampoco — no es que sacara cero. */}
+                            {d.calibres.some((c) => c.bins != null)
+                              ? d.calibres
+                                  .map((c) =>
+                                    c.bins == null ? "—" : c.bins.toLocaleString("es-CL")
+                                  )
+                                  .join(" / ")
+                              : "—"}
                           </td>
                           <td className="py-2.5 text-right text-slate-400 text-xs">
                             {d.lastTimestamp

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -38,6 +38,12 @@ interface Lote {
   productoNombre?: string;
 }
 
+/** Cajas que entraron al lote y bins declarados de salida. */
+interface Contenedores {
+  cajasEntrada: number;
+  binsSalida: number | null;
+}
+
 interface DeviceSummary {
   dispositivo: string;
   salidaOrden: number | null;
@@ -120,6 +126,7 @@ export default function LoteDetailPage() {
   // Resumen tab
   const [summary, setSummary] = useState<DeviceSummary[] | null>(null);
   const [summaryLoading, setSummaryLoading] = useState(false);
+  const [contenedores, setContenedores] = useState<Contenedores | null>(null);
 
   // Calibres tab
   const [chartData, setChartData] = useState<CaliberDataPoint[]>([]);
@@ -178,6 +185,17 @@ export default function LoteDetailPage() {
       })
       .catch(console.error)
       .finally(() => setSummaryLoading(false));
+  }, [loteId]);
+
+  // ── Fetch contenedores (cajas de entrada / bins de salida) ─────────────────
+  useEffect(() => {
+    if (!loteId) return;
+    fetch(`/api/lotes/${loteId}/contenedores`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Error al cargar contenedores");
+        setContenedores(await res.json());
+      })
+      .catch(console.error);
   }, [loteId]);
 
   // ── Fetch calibres ─────────────────────────────────────────────────────────
@@ -360,17 +378,35 @@ export default function LoteDetailPage() {
         <TabsContent value="resumen">
           <Card className="border-white/10 bg-slate-900/40">
             <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <CardTitle className="text-white">Resumen de dispositivos</CardTitle>
-                {summary && summary.length > 0 && (
-                  <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/40">
-                    Total:{" "}
-                    {summary
-                      .reduce((acc, d) => acc + (d.countIn ?? 0) + (d.countOut ?? 0), 0)
-                      .toLocaleString("es-CL")}{" "}
-                    bulbos
-                  </Badge>
-                )}
+                <div className="flex flex-wrap items-center gap-2">
+                  {/* Cajas de entrada y bins de salida: son del lote, no de cada
+                      salida. Una misma caja se asigna a las cuatro salidas a la
+                      vez, asi que por fila saldria el mismo numero repetido. */}
+                  {contenedores && (
+                    <>
+                      <Badge className="bg-emerald-500/15 text-emerald-300 border-emerald-500/40">
+                        Entraron: {contenedores.cajasEntrada.toLocaleString("es-CL")} cajas
+                      </Badge>
+                      <Badge className="bg-orange-500/15 text-orange-300 border-orange-500/40">
+                        Salieron:{" "}
+                        {contenedores.binsSalida == null
+                          ? "sin declarar"
+                          : `${contenedores.binsSalida.toLocaleString("es-CL")} bins`}
+                      </Badge>
+                    </>
+                  )}
+                  {summary && summary.length > 0 && (
+                    <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/40">
+                      Total:{" "}
+                      {summary
+                        .reduce((acc, d) => acc + (d.countIn ?? 0) + (d.countOut ?? 0), 0)
+                        .toLocaleString("es-CL")}{" "}
+                      bulbos
+                    </Badge>
+                  )}
+                </div>
               </div>
             </CardHeader>
             <CardContent>

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -52,6 +52,8 @@ interface DeviceSummary {
   // modelo admite varios tramos si se recalibra a mitad de proceso.
   /** Calibre declarado por esta salida en el lote, con sus bins. */
   calibres: Array<{ etiqueta: string; bins: number | null }>;
+  /** Lo marca el backend; no se deduce del texto de la etiqueta. */
+  esMerma: boolean;
   countIn: number;
   countOut: number;
   lastTimestamp: string | null;
@@ -400,8 +402,11 @@ export default function LoteDetailPage() {
                   )}
                   {summary && summary.length > 0 && (
                     <Badge className="bg-cyan-500/20 text-cyan-300 border-cyan-500/40">
+                      {/* El total excluye la merma: es lo que salió calibrado.
+                          La merma no se pierde, queda en su propia fila. */}
                       Total:{" "}
                       {summary
+                        .filter((d) => !d.esMerma)
                         .reduce((acc, d) => acc + (d.countIn ?? 0) + (d.countOut ?? 0), 0)
                         .toLocaleString("es-CL")}{" "}
                       bulbos
@@ -490,10 +495,21 @@ export default function LoteDetailPage() {
                               )}
                             </span>
                           </td>
-                          <td className="py-2.5 pr-4 text-right text-green-400">
+                          {/* La merma va en gris y no en verde/rojo: queda fuera
+                              del total, y el color distinto es la unica pista
+                              visual de que esa fila no suma. */}
+                          <td
+                            className={`py-2.5 pr-4 text-right ${
+                              d.esMerma ? "text-slate-500" : "text-green-400"
+                            }`}
+                          >
                             {d.countIn.toLocaleString("es-CL")}
                           </td>
-                          <td className="py-2.5 pr-4 text-right text-red-400">
+                          <td
+                            className={`py-2.5 pr-4 text-right ${
+                              d.esMerma ? "text-slate-500" : "text-red-400"
+                            }`}
+                          >
                             {d.countOut.toLocaleString("es-CL")}
                           </td>
                           <td className="py-2.5 pr-4 text-right text-orange-300">

--- a/my-project/src/emails/ServiceReportEmail.tsx
+++ b/my-project/src/emails/ServiceReportEmail.tsx
@@ -42,14 +42,67 @@ const th: React.CSSProperties = {
 };
 
 /**
- * Detalle por calibre y, debajo de cada uno, el aporte de cada salida.
+ * Detalle de UN lote: una fila por calibre, con la salida que lo saco.
+ *
+ * Dentro de un lote cada calibre pertenece a una sola salida, asi que van en la
+ * misma fila en vez de como subfilas — no hay nada que desglosar. Ese 1 a 1 no
+ * se cumple al agregar varios lotes: la misma salida corre calibres distintos en
+ * lotes distintos, y por eso el detalle se presenta por lote y no sumado.
  *
  * Se arma con una <table> y estilos inline a proposito: los clientes de correo
- * no soportan flex ni grid de forma confiable. Las salidas van como filas hijas
- * en vez de columnas para que la tabla siga siendo legible en un celular.
+ * no soportan flex ni grid de forma confiable.
  */
-function CalibreTable({ report }: { report: ServiceReport }) {
-  if (report.rows.length === 0) {
+function LoteTable({ lote }: { lote: ServiceReport["lotes"][number] }) {
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", margin: "0 0 18px" }}>
+      <thead>
+        <tr>
+          <th style={th}>Calibre / Size</th>
+          <th style={th}>Salida / Outlet</th>
+          <th style={{ ...th, textAlign: "right" }}>Bulbos</th>
+          <th style={{ ...th, textAlign: "right" }}>%</th>
+          <th style={{ ...th, textAlign: "right" }}>Bins</th>
+        </tr>
+      </thead>
+      <tbody>
+        {lote.rows.map((row) => (
+          <tr key={row.key}>
+            <td style={{ ...cell, fontWeight: 700 }}>{row.label}</td>
+            <td style={{ ...cell, color: "#475569" }}>
+              {row.salidas.length === 0
+                ? "—"
+                : row.salidas.map((s) => s.label).join(", ")}
+            </td>
+            <td style={{ ...cellNum, fontWeight: 700 }}>{num(row.bulbs)}</td>
+            <td style={cellNum}>{pct(row.percent)}</td>
+            <td style={cellNum}>{row.bins ? num(row.bins) : "-"}</td>
+          </tr>
+        ))}
+        {/* La merma va al pie y rotulada "fuera del total": es descarte, no un
+            calibre mas, y no esta sumada en los bulbos del lote. */}
+        {lote.mermaBulbs > 0 && (
+          <tr>
+            <td style={{ ...cell, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
+              Merma / Waste
+            </td>
+            <td style={{ ...cell, color: "#94A3B8", borderTop: "2px solid #E2E8F0" }}>
+              fuera del total / excluded
+            </td>
+            <td style={{ ...cellNum, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
+              {num(lote.mermaBulbs)}
+            </td>
+            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
+            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+/** Bloque por lote: encabezado con sus totales y su tabla de calibres. */
+function DetallePorLote({ report }: { report: ServiceReport }) {
+  if (report.lotes.length === 0) {
     return (
       <Text style={{ color: "#94A3B8", fontSize: 12, margin: "0 0 8px" }}>
         Sin datos para el periodo / No data for this period.
@@ -58,52 +111,27 @@ function CalibreTable({ report }: { report: ServiceReport }) {
   }
 
   return (
-    <table style={{ width: "100%", borderCollapse: "collapse", margin: "0 0 6px" }}>
-      <thead>
-        <tr>
-          <th style={th}>Calibre / Size</th>
-          <th style={{ ...th, textAlign: "right" }}>Bulbos</th>
-          <th style={{ ...th, textAlign: "right" }}>%</th>
-          <th style={{ ...th, textAlign: "right" }}>Bins</th>
-        </tr>
-      </thead>
-      <tbody>
-        {report.rows.map((row) => [
-          <tr key={row.key}>
-            <td style={{ ...cell, fontWeight: 700 }}>{row.label}</td>
-            <td style={{ ...cellNum, fontWeight: 700 }}>{num(row.bulbs)}</td>
-            <td style={cellNum}>{pct(row.percent)}</td>
-            <td style={cellNum}>{row.bins ? num(row.bins) : "-"}</td>
-          </tr>,
-          ...row.salidas.map((salida) => (
-            <tr key={`${row.key}:${salida.dispositivoNombre}`}>
-              <td style={{ ...cell, paddingLeft: 22, color: "#475569" }}>
-                {salida.label}
-                <span style={{ color: "#94A3B8" }}> · {salida.dispositivoNombre}</span>
-              </td>
-              <td style={{ ...cellNum, color: "#475569" }}>{num(salida.bulbs)}</td>
-              <td style={{ ...cellNum, color: "#94A3B8" }}>{pct(salida.percent)}</td>
-              <td style={cellNum}>-</td>
-            </tr>
-          )),
-        ])}
-        {/* La merma va al pie y rotulada "fuera del total": es descarte, no un
-            calibre mas, y no esta sumada en los bulbos de arriba. */}
-        {report.mermaBulbs > 0 && (
-          <tr>
-            <td style={{ ...cell, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
-              Merma / Waste
-              <span style={{ color: "#94A3B8" }}> · fuera del total / excluded</span>
-            </td>
-            <td style={{ ...cellNum, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
-              {num(report.mermaBulbs)}
-            </td>
-            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
-            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
-          </tr>
-        )}
-      </tbody>
-    </table>
+    <>
+      {report.lotes.map((lote) => (
+        <div key={lote.loteId}>
+          <Text
+            style={{
+              color: "#0E7490",
+              fontSize: 13,
+              fontWeight: 700,
+              margin: "14px 0 2px",
+            }}
+          >
+            Lote / Lot {lote.codigoLote}
+          </Text>
+          <Text style={{ color: "#64748B", fontSize: 11, margin: "0 0 6px" }}>
+            {num(lote.bulbs)} bulbos procesados / processed
+            {lote.mermaBulbs > 0 ? ` · + ${num(lote.mermaBulbs)} merma / waste` : ""}
+          </Text>
+          <LoteTable lote={lote} />
+        </div>
+      ))}
+    </>
   );
 }
 
@@ -157,19 +185,23 @@ export default function ServiceReportEmail({ daily, total, recipientName }: Serv
             <Hr style={{ borderColor: "#E2E8F0", margin: "24px 0" }} />
 
             <Text style={{ color: "#172033", fontSize: 14, fontWeight: 700, margin: "0 0 2px" }}>
-              Detalle del dia / Daily detail
+              Detalle del dia por lote / Daily detail by lot
             </Text>
-            <Text style={{ color: "#94A3B8", fontSize: 11, margin: "0 0 10px" }}>
+            <Text style={{ color: "#94A3B8", fontSize: 11, margin: "0 0 4px" }}>
               {daily.calibreSource === "declarado"
-                ? "Por calibre y salida. El % de cada salida es su peso dentro del calibre / By size and outlet. Each outlet's % is its share within the size."
+                ? "El % es dentro del lote. La merma va aparte y no suma al total / % is within the lot. Waste is listed separately and excluded from the total."
                 : "Por calibre medido / By measured size."}
             </Text>
-            <CalibreTable report={daily} />
+            <DetallePorLote report={daily} />
 
-            <Text style={{ color: "#172033", fontSize: 14, fontWeight: 700, margin: "22px 0 10px" }}>
-              Acumulado del servicio / Service total
+            <Hr style={{ borderColor: "#E2E8F0", margin: "24px 0" }} />
+            <Text style={{ color: "#172033", fontSize: 14, fontWeight: 700, margin: "0 0 2px" }}>
+              Acumulado del servicio por lote / Service total by lot
             </Text>
-            <CalibreTable report={total} />
+            <Text style={{ color: "#94A3B8", fontSize: 11, margin: "0 0 4px" }}>
+              Todo el servicio, no solo el dia reportado / Whole service, not just the reported day.
+            </Text>
+            <DetallePorLote report={total} />
 
             <Hr style={{ borderColor: "#E2E8F0", margin: "24px 0" }} />
             <Text style={{ color: "#475569", fontSize: 13, lineHeight: "20px" }}>

--- a/my-project/src/emails/ServiceReportEmail.tsx
+++ b/my-project/src/emails/ServiceReportEmail.tsx
@@ -133,7 +133,7 @@ export default function ServiceReportEmail({ daily, total, recipientName }: Serv
                 <Section style={{ backgroundColor: "#E0F2FE", padding: 14 }}>
                   <Text style={{ color: "#64748B", fontSize: 11, margin: 0 }}>RESUMEN DEL DIA / DAILY SUMMARY</Text>
                   <Text style={{ color: "#0E7490", fontSize: 24, fontWeight: 700, margin: "4px 0" }}>{daily.totalBulbs.toLocaleString("es-CL")}</Text>
-                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>calibrados / graded - {daily.lotes.length} lotes / lots</Text>
+                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>procesados / processed - {daily.lotes.length} lotes / lots</Text>
                   {daily.mermaBulbs > 0 && (
                     <Text style={{ color: "#B45309", fontSize: 12, margin: "4px 0 0" }}>
                       + {daily.mermaBulbs.toLocaleString("es-CL")} merma / waste
@@ -145,7 +145,7 @@ export default function ServiceReportEmail({ daily, total, recipientName }: Serv
                 <Section style={{ backgroundColor: "#F8FAFC", padding: 14 }}>
                   <Text style={{ color: "#64748B", fontSize: 11, margin: 0 }}>TOTAL DEL SERVICIO / SERVICE TOTAL</Text>
                   <Text style={{ color: "#172033", fontSize: 24, fontWeight: 700, margin: "4px 0" }}>{total.totalBulbs.toLocaleString("es-CL")}</Text>
-                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>calibrados / graded - {total.lotes.length} lotes / lots</Text>
+                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>procesados / processed - {total.lotes.length} lotes / lots</Text>
                   {total.mermaBulbs > 0 && (
                     <Text style={{ color: "#B45309", fontSize: 12, margin: "4px 0 0" }}>
                       + {total.mermaBulbs.toLocaleString("es-CL")} merma / waste

--- a/my-project/src/emails/ServiceReportEmail.tsx
+++ b/my-project/src/emails/ServiceReportEmail.tsx
@@ -87,6 +87,21 @@ function CalibreTable({ report }: { report: ServiceReport }) {
             </tr>
           )),
         ])}
+        {/* La merma va al pie y rotulada "fuera del total": es descarte, no un
+            calibre mas, y no esta sumada en los bulbos de arriba. */}
+        {report.mermaBulbs > 0 && (
+          <tr>
+            <td style={{ ...cell, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
+              Merma / Waste
+              <span style={{ color: "#94A3B8" }}> · fuera del total / excluded</span>
+            </td>
+            <td style={{ ...cellNum, color: "#B45309", borderTop: "2px solid #E2E8F0" }}>
+              {num(report.mermaBulbs)}
+            </td>
+            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
+            <td style={{ ...cellNum, borderTop: "2px solid #E2E8F0" }}>—</td>
+          </tr>
+        )}
       </tbody>
     </table>
   );
@@ -118,14 +133,24 @@ export default function ServiceReportEmail({ daily, total, recipientName }: Serv
                 <Section style={{ backgroundColor: "#E0F2FE", padding: 14 }}>
                   <Text style={{ color: "#64748B", fontSize: 11, margin: 0 }}>RESUMEN DEL DIA / DAILY SUMMARY</Text>
                   <Text style={{ color: "#0E7490", fontSize: 24, fontWeight: 700, margin: "4px 0" }}>{daily.totalBulbs.toLocaleString("es-CL")}</Text>
-                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>bulbos / bulbs - {daily.lotes.length} lotes / lots</Text>
+                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>calibrados / graded - {daily.lotes.length} lotes / lots</Text>
+                  {daily.mermaBulbs > 0 && (
+                    <Text style={{ color: "#B45309", fontSize: 12, margin: "4px 0 0" }}>
+                      + {daily.mermaBulbs.toLocaleString("es-CL")} merma / waste
+                    </Text>
+                  )}
                 </Section>
               </Column>
               <Column style={{ width: "50%", paddingLeft: 6 }}>
                 <Section style={{ backgroundColor: "#F8FAFC", padding: 14 }}>
                   <Text style={{ color: "#64748B", fontSize: 11, margin: 0 }}>TOTAL DEL SERVICIO / SERVICE TOTAL</Text>
                   <Text style={{ color: "#172033", fontSize: 24, fontWeight: 700, margin: "4px 0" }}>{total.totalBulbs.toLocaleString("es-CL")}</Text>
-                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>bulbos / bulbs - {total.lotes.length} lotes / lots</Text>
+                  <Text style={{ color: "#475569", fontSize: 12, margin: 0 }}>calibrados / graded - {total.lotes.length} lotes / lots</Text>
+                  {total.mermaBulbs > 0 && (
+                    <Text style={{ color: "#B45309", fontSize: 12, margin: "4px 0 0" }}>
+                      + {total.mermaBulbs.toLocaleString("es-CL")} merma / waste
+                    </Text>
+                  )}
                 </Section>
               </Column>
             </Row>

--- a/my-project/src/lib/lote-contenedores.ts
+++ b/my-project/src/lib/lote-contenedores.ts
@@ -1,0 +1,59 @@
+import { db } from "@/db";
+import { loteCierreCalibreBin } from "@/db/schema";
+import { eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { getCajaCountForLote } from "@/lib/app-session";
+
+/**
+ * Contenedores de un lote: los que entraron y los que salieron.
+ *
+ * Son dos tablas distintas y conviene no confundirlas:
+ *
+ *  - Entrada: `caja`, el contenedor físico con QR que se asigna a la sesión de
+ *    lote (`caja_lote_session`). Una misma caja se asigna a TODAS las salidas a
+ *    la vez, porque su producto se reparte entre ellas — por eso el conteo es
+ *    del lote y no tiene sentido por salida.
+ *  - Salida: los bins que la operaria declara por calibre al cerrar
+ *    (`lote_cierre_calibre_bin.bins`). Esos sí son por salida.
+ */
+export interface ContenedoresLote {
+  /** Cajas distintas que entraron al lote. */
+  cajasEntrada: number;
+  /** Bins declarados de salida. Null si el lote no tiene ninguna declaración. */
+  binsSalida: number | null;
+}
+
+export async function contenedoresDelLote(loteId: string): Promise<ContenedoresLote> {
+  // Cajas distintas, misma definición que ya usa la tablet para el numero de
+  // orden de caja — se reutiliza para no tener dos formas de contar lo mismo.
+  const cajasEntrada = await getCajaCountForLote(loteId);
+
+  // La tabla convive en dos regímenes (ver schema): filas por salida
+  // (dispositivo_id NOT NULL) y filas legacy a nivel de lote. Sumar ambas
+  // duplicaría, así que se prefiere el desglose por salida cuando existe.
+  const [porSalida] = await db
+    .select({ bins: sql<string | null>`SUM(${loteCierreCalibreBin.bins})` })
+    .from(loteCierreCalibreBin)
+    .where(
+      sql`${eq(loteCierreCalibreBin.loteId, loteId)} and ${isNotNull(
+        loteCierreCalibreBin.dispositivoId
+      )}`
+    );
+
+  if (porSalida?.bins != null) {
+    return { cajasEntrada, binsSalida: Number(porSalida.bins) };
+  }
+
+  const [legacy] = await db
+    .select({ bins: sql<string | null>`SUM(${loteCierreCalibreBin.bins})` })
+    .from(loteCierreCalibreBin)
+    .where(
+      sql`${eq(loteCierreCalibreBin.loteId, loteId)} and ${isNull(
+        loteCierreCalibreBin.dispositivoId
+      )}`
+    );
+
+  return {
+    cajasEntrada,
+    binsSalida: legacy?.bins == null ? null : Number(legacy.bins),
+  };
+}

--- a/my-project/src/lib/reporting/data.ts
+++ b/my-project/src/lib/reporting/data.ts
@@ -198,6 +198,8 @@ function buildLote(
     codigoLote,
     bulbs,
     percent: 0,
+    // Modo medido: el calibre sale del perimetro, no hay salida que declare.
+    mermaBulbs: 0,
     rows: [...buckets.values()]
       .sort(sortCalibreRows)
       .map((bucket) => ({
@@ -272,10 +274,10 @@ async function buildDeclaredServiceReport(metadata: { serviceName: string; compa
   if (kind === "daily") conditions.push(eq(loteCalibreDeclaradoDia.dia, reportDate));
   const summary = await db.select().from(loteCalibreDeclaradoDia).where(and(...conditions));
   const usedLoteIds = [...new Set(summary.map((row) => row.loteId))];
-  if (usedLoteIds.length === 0) return { kind, serviceId, serviceName: metadata.serviceName, companyName: metadata.companyName, processName: metadata.processName, reportDate, generatedAt: new Date().toISOString(), calibreSource: "declarado", totalBulbs: 0, rows: [], lotes: [] };
+  if (usedLoteIds.length === 0) return { kind, serviceId, serviceName: metadata.serviceName, companyName: metadata.companyName, processName: metadata.processName, reportDate, generatedAt: new Date().toISOString(), calibreSource: "declarado", totalBulbs: 0, rows: [], lotes: [], mermaBulbs: 0 };
   const names = await db.select({ id: lote.id, codigo: lote.codigoLote }).from(lote).where(inArray(lote.id, usedLoteIds));
   const nameMap = new Map(names.map((row) => [row.id, row.codigo ?? row.id.slice(0, 8)]));
-  const declarations = await db.select({ loteId: loteCierreCalibreBin.loteId, from: loteCierreCalibreBin.calibreFrom, to: loteCierreCalibreBin.calibreTo, bins: loteCierreCalibreBin.bins }).from(loteCierreCalibreBin).where(and(eq(loteCierreCalibreBin.servicioId, serviceId), inArray(loteCierreCalibreBin.loteId, usedLoteIds), isNotNull(loteCierreCalibreBin.dispositivoId)));
+  const declarations = await db.select({ loteId: loteCierreCalibreBin.loteId, dispositivoId: loteCierreCalibreBin.dispositivoId, from: loteCierreCalibreBin.calibreFrom, to: loteCierreCalibreBin.calibreTo, bins: loteCierreCalibreBin.bins }).from(loteCierreCalibreBin).where(and(eq(loteCierreCalibreBin.servicioId, serviceId), inArray(loteCierreCalibreBin.loteId, usedLoteIds), isNotNull(loteCierreCalibreBin.dispositivoId)));
   const bins = new Map<string, number>();
   for (const row of declarations) { const key = `${row.loteId}:${row.from ?? ""}:${row.to ?? ""}`; bins.set(key, (bins.get(key) ?? 0) + (Number(row.bins) || 0)); }
   // Etiqueta de cada salida del servicio. Se resuelve una vez y no por fila:
@@ -303,8 +305,23 @@ async function buildDeclaredServiceReport(metadata: { serviceName: string; compa
     ])
   );
 
+  // Que salidas declararon algo en cada lote. Es el criterio que separa la merma
+  // del producto pendiente dentro del balde "sin declarar": una salida que nunca
+  // declaro en el lote saco merma; una que si declaro y tiene unidades fuera de
+  // sus rangos es producto que todavia no se declara. Mismo criterio que usa la
+  // tabla del lote (ver @/lib/salida-calibre).
+  const declaroEnLote = new Set(
+    declarations.map((row) => `${row.loteId}|${row.dispositivoId}`)
+  );
+
+  const mermaPorLote = new Map<string, number>();
   const byLote = new Map<string, Map<string, ReportCalibreRow>>();
   for (const row of summary) {
+    if (row.sinDeclarar && !declaroEnLote.has(`${row.loteId}|${row.dispositivoId}`)) {
+      const unidades = Number(row.unidades) || 0;
+      mermaPorLote.set(row.loteId, (mermaPorLote.get(row.loteId) ?? 0) + unidades);
+      continue;
+    }
     const key = row.sinDeclarar ? "sin_declarar" : `${row.calibreFrom ?? ""}:${row.calibreTo ?? ""}`;
     const rows = byLote.get(row.loteId) ?? new Map<string, ReportCalibreRow>();
     const current = rows.get(key) ?? { key, label: declaredLabel(row.calibreFrom, row.calibreTo, row.sinDeclarar), bulbs: 0, bins: row.sinDeclarar ? 0 : bins.get(`${row.loteId}:${row.calibreFrom ?? ""}:${row.calibreTo ?? ""}`) ?? 0, percent: 0, salidas: [] };
@@ -328,9 +345,14 @@ async function buildDeclaredServiceReport(metadata: { serviceName: string; compa
     }
     rows.set(key, current); byLote.set(row.loteId, rows);
   }
-  const lotes = [...byLote.entries()].map(([loteId, rows]) => { const values = [...rows.values()].sort(sortCalibreRows); const bulbs = values.reduce((sum, row) => sum + row.bulbs, 0); return { loteId, codigoLote: nameMap.get(loteId) ?? loteId.slice(0, 8), bulbs, percent: 0, rows: values.map((row) => ({ ...row, percent: roundedPercent(row.bulbs, bulbs), salidas: finishSalidas(row.salidas, row.bulbs) })) }; }).sort((a, b) => a.codigoLote.localeCompare(b.codigoLote, "es"));
+  // Un lote puede tener SOLO merma (nada declarado que mostrar), asi que se
+  // recorren las claves de los dos mapas y no solo las de byLote.
+  const loteIdsConDatos = [...new Set([...byLote.keys(), ...mermaPorLote.keys()])];
+  const lotes = loteIdsConDatos.map((loteId) => { const values = [...(byLote.get(loteId)?.values() ?? [])].sort(sortCalibreRows); const bulbs = values.reduce((sum, row) => sum + row.bulbs, 0); return { loteId, codigoLote: nameMap.get(loteId) ?? loteId.slice(0, 8), bulbs, percent: 0, rows: values.map((row) => ({ ...row, percent: roundedPercent(row.bulbs, bulbs), salidas: finishSalidas(row.salidas, row.bulbs) })), mermaBulbs: mermaPorLote.get(loteId) ?? 0 }; }).sort((a, b) => a.codigoLote.localeCompare(b.codigoLote, "es"));
+  // `bulbs` y `totalBulbs` son producto calibrado: la merma va aparte, no suma.
   const totalBulbs = lotes.reduce((sum, row) => sum + row.bulbs, 0); for (const row of lotes) row.percent = roundedPercent(row.bulbs, totalBulbs);
-  return { kind, serviceId, serviceName: metadata.serviceName, companyName: metadata.companyName, processName: metadata.processName, reportDate, generatedAt: new Date().toISOString(), calibreSource: "declarado", totalBulbs, rows: mergeServiceRows(lotes), lotes };
+  const mermaBulbs = lotes.reduce((sum, row) => sum + row.mermaBulbs, 0);
+  return { kind, serviceId, serviceName: metadata.serviceName, companyName: metadata.companyName, processName: metadata.processName, reportDate, generatedAt: new Date().toISOString(), calibreSource: "declarado", totalBulbs, rows: mergeServiceRows(lotes), lotes, mermaBulbs };
 }
 
 /** Reporte diario en modo medido: un dia acotado por indice sobre `conteo`. */
@@ -455,6 +477,7 @@ export async function buildServiceReport(
       totalBulbs: 0,
       rows: [],
       lotes: [],
+      mermaBulbs: 0,
     };
   }
 
@@ -531,5 +554,6 @@ export async function buildServiceReport(
     totalBulbs,
     rows: mergeServiceRows(lotes),
     lotes,
+    mermaBulbs: 0,
   };
 }

--- a/my-project/src/lib/reporting/data.ts
+++ b/my-project/src/lib/reporting/data.ts
@@ -288,22 +288,48 @@ async function buildDeclaredServiceReport(metadata: { serviceName: string; compa
       dispositivoNombre: dispositivo.nombre,
       salidaOrden: dispositivoServicio.salidaOrden,
       salidaNombre: dispositivoServicio.salidaNombre,
+      fechaTermino: dispositivoServicio.fechaTermino,
     })
     .from(dispositivoServicio)
     .innerJoin(dispositivo, eq(dispositivo.id, dispositivoServicio.dispositivoId))
     .where(eq(dispositivoServicio.servicioId, serviceId));
-  const salidaPorDispositivo = new Map(
-    salidaRows.map((row) => [
-      row.dispositivoId,
-      {
-        salidaOrden: row.salidaOrden,
-        // Misma convención que el resto: sin salida configurada se cae al
-        // nombre del equipo en vez de mostrar un hueco.
-        label: row.salidaNombre ?? row.dispositivoNombre,
-        dispositivoNombre: row.dispositivoNombre,
-      },
-    ])
-  );
+
+  // La salida de un equipo es FIJA: THOR-1 es Salida 1 aunque no pase un solo
+  // bulbo por ahi. Nunca se renumera ni se deriva de quien produjo — sale de
+  // dispositivo_servicio.salida_orden.
+  //
+  // Un equipo puede tener mas de un vinculo con el mismo servicio (uno terminado
+  // y uno vigente). Sin elegir, el Map se quedaba con la ultima fila que llegara
+  // de la DB, que puede ser la del vinculo viejo y con otro numero de salida.
+  // Se prefiere el vigente (fecha_termino NULL) y, ante empate, el de menor orden.
+  const salidaPorDispositivo = new Map<
+    string,
+    { salidaOrden: number | null; label: string; dispositivoNombre: string; vigente: boolean }
+  >();
+  for (const row of salidaRows) {
+    const candidato = {
+      salidaOrden: row.salidaOrden,
+      // Misma convención que el resto: sin salida configurada se cae al
+      // nombre del equipo en vez de mostrar un hueco.
+      label: row.salidaNombre ?? row.dispositivoNombre,
+      dispositivoNombre: row.dispositivoNombre,
+      vigente: row.fechaTermino === null,
+    };
+    const actual = salidaPorDispositivo.get(row.dispositivoId);
+    if (
+      !actual ||
+      (candidato.vigente && !actual.vigente) ||
+      (candidato.vigente === actual.vigente &&
+        actual.salidaOrden == null &&
+        candidato.salidaOrden != null) ||
+      (candidato.vigente === actual.vigente &&
+        actual.salidaOrden != null &&
+        candidato.salidaOrden != null &&
+        candidato.salidaOrden < actual.salidaOrden)
+    ) {
+      salidaPorDispositivo.set(row.dispositivoId, candidato);
+    }
+  }
 
   // Que salidas declararon algo en cada lote. Es el criterio que separa la merma
   // del producto pendiente dentro del balde "sin declarar": una salida que nunca

--- a/my-project/src/lib/reporting/pdf.tsx
+++ b/my-project/src/lib/reporting/pdf.tsx
@@ -162,8 +162,8 @@ export function ServiceReportDocument({ report }: { report: ServiceReport }): Re
         </View>
 
         <View style={styles.cards}>
-          {/* "Calibrados" y no "procesados": la merma quedo fuera de totalBulbs. */}
-          <View style={styles.card}><Text style={styles.cardLabel}>Bulbos calibrados{"\n"}/ Graded bulbs</Text><Text style={styles.cardValue}>{number(report.totalBulbs)}</Text></View>
+          {/* Ojo: no incluye la merma, que va en su propia tarjeta al lado. */}
+          <View style={styles.card}><Text style={styles.cardLabel}>Bulbos procesados{"\n"}/ Processed bulbs</Text><Text style={styles.cardValue}>{number(report.totalBulbs)}</Text></View>
           {report.mermaBulbs > 0 && (
             <View style={styles.card}><Text style={styles.cardLabel}>Merma / Waste{"\n"}(fuera del total)</Text><Text style={styles.cardValue}>{number(report.mermaBulbs)}</Text></View>
           )}

--- a/my-project/src/lib/reporting/pdf.tsx
+++ b/my-project/src/lib/reporting/pdf.tsx
@@ -43,6 +43,7 @@ const styles = StyleSheet.create({
   // Fila hija de una salida: sin borde propio y con sangria, para que se lea
   // colgando del calibre de arriba y no como otro calibre.
   salidaRow: { borderTopWidth: 0, paddingVertical: 3 },
+  mermaRow: { backgroundColor: "#FEF3C7" },
   colSalidaLabel: { width: "46%", paddingLeft: 10, color: colors.muted, fontSize: 8 },
   colBulbs: { width: "18%", textAlign: "right" },
   colPercent: { width: "18%", textAlign: "right" },
@@ -85,13 +86,16 @@ function LoteSection({ lote }: { lote: ReportLote }) {
     <View style={styles.loteBlock} wrap={lote.rows.length > UNSPLITTABLE_ROWS}>
       <View style={styles.loteTitleRow}>
         <Text style={styles.loteTitle}>Lote / Lot {lote.codigoLote}</Text>
-        <Text style={styles.loteTotal}>{number(lote.bulbs)} bulbos - {number(lote.percent)}% del total</Text>
+        <Text style={styles.loteTotal}>
+          {number(lote.bulbs)} bulbos - {number(lote.percent)}% del total
+          {lote.mermaBulbs > 0 ? ` + ${number(lote.mermaBulbs)} merma` : ""}
+        </Text>
       </View>
       <View style={styles.table}>
         <View style={styles.tableHeader}>
           <Text style={styles.colLabel}>Calibre / Size</Text><Text style={styles.colBulbs}>Bulbos</Text><Text style={styles.colPercent}>%</Text><Text style={styles.colBins}>Bins</Text>
         </View>
-        {lote.rows.length === 0 ? (
+        {lote.rows.length === 0 && lote.mermaBulbs === 0 ? (
           <View style={styles.tableRow}><Text style={styles.colLabel}>Sin datos para el periodo</Text></View>
         ) : lote.rows.map((row, index) => (
           <View key={row.key} style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}]} wrap={false}>
@@ -101,6 +105,16 @@ function LoteSection({ lote }: { lote: ReportLote }) {
             <Text style={styles.colBins}>{row.bins ? number(row.bins) : "-"}</Text>
           </View>
         ))}
+        {/* Fila de merma del lote. Sin esto un lote que solo saco merma aparecia
+            como "sin datos", cuando en realidad si conto bulbos. */}
+        {lote.mermaBulbs > 0 && (
+          <View style={[styles.tableRow, styles.mermaRow]} wrap={false}>
+            <Text style={styles.colLabel}>Merma / Waste (fuera del total)</Text>
+            <Text style={styles.colBulbs}>{number(lote.mermaBulbs)}</Text>
+            <Text style={styles.colPercent}>-</Text>
+            <Text style={styles.colBins}>-</Text>
+          </View>
+        )}
       </View>
     </View>
   );
@@ -108,12 +122,19 @@ function LoteSection({ lote }: { lote: ReportLote }) {
 
 /** Tabla unica y paginable, para servicios con demasiados lotes. */
 function FlatDetailTable({ lotes }: { lotes: ReportLote[] }) {
-  const rows = lotes.flatMap((lote): Array<{ lote: ReportLote; row: ReportCalibreRow | null }> => {
-    if (lote.rows.length === 0) {
-      return [{ lote, row: null }];
+  // `merma: true` es una fila propia del lote, no un calibre. Va aca y no solo en
+  // LoteSection para que un servicio con muchos lotes no pierda el descarte.
+  const rows = lotes.flatMap(
+    (lote): Array<{ lote: ReportLote; row: ReportCalibreRow | null; merma?: boolean }> => {
+      const calibres =
+        lote.rows.length === 0 && lote.mermaBulbs === 0
+          ? [{ lote, row: null }]
+          : lote.rows.map((row) => ({ lote, row }));
+      return lote.mermaBulbs > 0
+        ? [...calibres, { lote, row: null, merma: true }]
+        : calibres;
     }
-    return lote.rows.map((row) => ({ lote, row }));
-  });
+  );
 
   return (
     <View style={styles.table}>
@@ -122,13 +143,23 @@ function FlatDetailTable({ lotes }: { lotes: ReportLote[] }) {
       </View>
       {rows.length === 0 ? (
         <View style={styles.tableRow}><Text style={styles.colLabel}>Sin datos para el periodo</Text></View>
-      ) : rows.map(({ lote, row }, index) => (
-        <View key={`${lote.loteId}-${row?.key ?? "empty"}`} style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}]} wrap={false}>
+      ) : rows.map(({ lote, row, merma }, index) => (
+        <View
+          key={`${lote.loteId}-${merma ? "merma" : row?.key ?? "empty"}`}
+          style={[styles.tableRow, index % 2 ? styles.tableRowAlt : {}, merma ? styles.mermaRow : {}]}
+          wrap={false}
+        >
           <Text style={styles.detailLot}>{lote.codigoLote}</Text>
-          <Text style={styles.detailCalibre}>{row?.label ?? "Sin datos para el periodo"}</Text>
-          <Text style={styles.detailBulbs}>{row ? number(row.bulbs) : "-"}</Text>
-          <Text style={styles.detailPercent}>{row ? `${number(row.percent)}%` : "-"}</Text>
-          <Text style={styles.detailBins}>{row?.bins ? number(row.bins) : "-"}</Text>
+          <Text style={styles.detailCalibre}>
+            {merma
+              ? "Merma / Waste (fuera del total)"
+              : row?.label ?? "Sin datos para el periodo"}
+          </Text>
+          <Text style={styles.detailBulbs}>
+            {merma ? number(lote.mermaBulbs) : row ? number(row.bulbs) : "-"}
+          </Text>
+          <Text style={styles.detailPercent}>{!merma && row ? `${number(row.percent)}%` : "-"}</Text>
+          <Text style={styles.detailBins}>{!merma && row?.bins ? number(row.bins) : "-"}</Text>
         </View>
       ))}
     </View>

--- a/my-project/src/lib/reporting/pdf.tsx
+++ b/my-project/src/lib/reporting/pdf.tsx
@@ -162,7 +162,11 @@ export function ServiceReportDocument({ report }: { report: ServiceReport }): Re
         </View>
 
         <View style={styles.cards}>
-          <View style={styles.card}><Text style={styles.cardLabel}>Bulbos procesados{"\n"}/ Processed bulbs</Text><Text style={styles.cardValue}>{number(report.totalBulbs)}</Text></View>
+          {/* "Calibrados" y no "procesados": la merma quedo fuera de totalBulbs. */}
+          <View style={styles.card}><Text style={styles.cardLabel}>Bulbos calibrados{"\n"}/ Graded bulbs</Text><Text style={styles.cardValue}>{number(report.totalBulbs)}</Text></View>
+          {report.mermaBulbs > 0 && (
+            <View style={styles.card}><Text style={styles.cardLabel}>Merma / Waste{"\n"}(fuera del total)</Text><Text style={styles.cardValue}>{number(report.mermaBulbs)}</Text></View>
+          )}
           <View style={styles.card}><Text style={styles.cardLabel}>Lotes procesados{"\n"}/ Processed lots</Text><Text style={styles.cardValue}>{number(report.lotes.length)}</Text></View>
         </View>
 

--- a/my-project/src/lib/reporting/types.ts
+++ b/my-project/src/lib/reporting/types.ts
@@ -31,7 +31,10 @@ export interface ReportCalibreRow {
 export interface ReportLote {
   loteId: string;
   codigoLote: string;
-  /** Bulbos calibrados. NO incluye la merma. */
+  /**
+   * Bulbos con calibre declarado. NO incluye la merma — se muestra como
+   * "Bulbos procesados", pero el numero deja el descarte fuera.
+   */
   bulbs: number;
   percent: number;
   rows: ReportCalibreRow[];
@@ -52,7 +55,10 @@ export interface ServiceReport {
   reportDate: string;
   generatedAt: string;
   calibreSource: "medido" | "declarado";
-  /** Bulbos calibrados. NO incluye la merma. */
+  /**
+   * Bulbos con calibre declarado. NO incluye la merma — se muestra como
+   * "Bulbos procesados", pero el numero deja el descarte fuera.
+   */
   totalBulbs: number;
   rows: ReportCalibreRow[];
   lotes: ReportLote[];

--- a/my-project/src/lib/reporting/types.ts
+++ b/my-project/src/lib/reporting/types.ts
@@ -31,9 +31,16 @@ export interface ReportCalibreRow {
 export interface ReportLote {
   loteId: string;
   codigoLote: string;
+  /** Bulbos calibrados. NO incluye la merma. */
   bulbs: number;
   percent: number;
   rows: ReportCalibreRow[];
+  /**
+   * Bulbos que salieron por una salida que no declaró calibre en este lote,
+   * habiendo el lote tenido cierre. Va aparte y fuera de `bulbs` porque es
+   * descarte, no producto calibrado.
+   */
+  mermaBulbs: number;
 }
 
 export interface ServiceReport {
@@ -45,9 +52,15 @@ export interface ServiceReport {
   reportDate: string;
   generatedAt: string;
   calibreSource: "medido" | "declarado";
+  /** Bulbos calibrados. NO incluye la merma. */
   totalBulbs: number;
   rows: ReportCalibreRow[];
   lotes: ReportLote[];
+  /**
+   * Merma del periodo, fuera de `totalBulbs`. Siempre 0 en modo medido: ahí el
+   * calibre sale del perímetro, no hay salida que declare ni deje de declarar.
+   */
+  mermaBulbs: number;
 }
 
 export interface ReportPair {

--- a/my-project/src/lib/reporting/xlsx.ts
+++ b/my-project/src/lib/reporting/xlsx.ts
@@ -33,9 +33,10 @@ function header(report: ServiceReport, title: string): Cell[][] {
     ],
     ["Origen del calibre / Size source", calibreSourceLabel(report)],
     [],
-    // "Calibrados" y no "procesados": la merma quedo fuera de totalBulbs, asi que
-    // llamarlo procesados seria decir que ese numero es todo lo que paso.
-    ["Bulbos calibrados / Graded bulbs", report.totalBulbs],
+    // Ojo: este numero NO incluye la merma, que va en la fila siguiente. La
+    // etiqueta dice "procesados" por decision del cliente; el desglose de abajo
+    // es lo que evita leerlo como el total de la linea.
+    ["Bulbos procesados / Processed bulbs", report.totalBulbs],
     ["Merma / Waste (fuera del total)", report.mermaBulbs],
     ["Lotes procesados / Processed lots", report.lotes.length],
     [],

--- a/my-project/src/lib/reporting/xlsx.ts
+++ b/my-project/src/lib/reporting/xlsx.ts
@@ -55,7 +55,9 @@ function detailRows(report: ServiceReport, withSalidas: boolean): Cell[][] {
     : ["Lote / Lot", "Calibre / Size", "Bulbos", "%", "Bins"];
   const rows: Cell[][] = [head];
   for (const lote of report.lotes) {
-    if (lote.rows.length === 0) {
+    // Un lote que solo saco merma tiene rows vacio pero SI conto bulbos: sin esta
+    // condicion caia en "Sin datos para el periodo" y su merma no se mostraba.
+    if (lote.rows.length === 0 && lote.mermaBulbs === 0) {
       rows.push(
         withSalidas
           ? [lote.codigoLote, "Sin datos para el periodo", null, null, null, null]
@@ -79,6 +81,18 @@ function detailRows(report: ServiceReport, withSalidas: boolean): Cell[][] {
         }
       }
     });
+    // La merma del lote, antes del total y rotulada como fuera de el: sin esta
+    // fila el detalle por lote mostraba los calibres pero escondia el descarte.
+    // Si el lote solo saco merma, esta es su primera fila y le toca llevar el
+    // codigo — que va solo en la primera fila de cada bloque.
+    if (lote.mermaBulbs > 0) {
+      const codigo = lote.rows.length === 0 ? lote.codigoLote : null;
+      rows.push(
+        withSalidas
+          ? [codigo, "Merma / Waste (fuera del total)", null, lote.mermaBulbs, null, null]
+          : [codigo, "Merma / Waste (fuera del total)", lote.mermaBulbs, null, null]
+      );
+    }
     rows.push(
       withSalidas
         ? [null, "Total lote / Lot total", null, lote.bulbs, lote.percent, null]

--- a/my-project/src/lib/reporting/xlsx.ts
+++ b/my-project/src/lib/reporting/xlsx.ts
@@ -33,7 +33,10 @@ function header(report: ServiceReport, title: string): Cell[][] {
     ],
     ["Origen del calibre / Size source", calibreSourceLabel(report)],
     [],
-    ["Bulbos procesados / Processed bulbs", report.totalBulbs],
+    // "Calibrados" y no "procesados": la merma quedo fuera de totalBulbs, asi que
+    // llamarlo procesados seria decir que ese numero es todo lo que paso.
+    ["Bulbos calibrados / Graded bulbs", report.totalBulbs],
+    ["Merma / Waste (fuera del total)", report.mermaBulbs],
     ["Lotes procesados / Processed lots", report.lotes.length],
     [],
   ];

--- a/my-project/src/lib/salida-calibre.ts
+++ b/my-project/src/lib/salida-calibre.ts
@@ -4,7 +4,7 @@ import {
   dispositivoServicio,
   loteCierreCalibreBin,
 } from "@/db/schema";
-import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 
 // Salida física de un calibrador y el calibre que declaró en un lote puntual.
 //
@@ -12,11 +12,23 @@ import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 // /app/servicios/[id]/lotes/[id]) alimentadas por endpoints distintos, y la
 // etiqueta tiene que salir igual en las dos.
 
+/** Un rango de calibre declarado por una salida, con los bins que sacó. */
+export interface CalibreDeclarado {
+  /** "10/12", o "merma" / "merma >20" en los rangos abiertos. */
+  etiqueta: string;
+  /** Bins declarados para este rango. Null en la merma, que no lleva bins. */
+  bins: number | null;
+}
+
 export interface SalidaCalibre {
   salidaOrden: number | null;
   salidaNombre: string | null;
-  /** Calibres declarados en el lote. Normalmente uno; varios si se recalibró. */
-  calibres: string[];
+  /**
+   * Calibres declarados en el lote. Normalmente uno — dentro de un lote cada
+   * calibre pertenece a una sola salida (34/34 casos reales) — pero pueden ser
+   * varios si se recalibró a mitad de proceso.
+   */
+  calibres: CalibreDeclarado[];
 }
 
 export interface ParDispositivoServicio {
@@ -120,6 +132,9 @@ export async function resolverSalidasCalibre(
       servicioId: loteCierreCalibreBin.servicioId,
       calibreFrom: loteCierreCalibreBin.calibreFrom,
       calibreTo: loteCierreCalibreBin.calibreTo,
+      // Se suma porque el group by es por rango: si un rango tuviera mas de una
+      // fila (misma salida, mismo calibre) los bins son del rango, no de la fila.
+      bins: sql<string | null>`SUM(${loteCierreCalibreBin.bins})`,
     })
     .from(loteCierreCalibreBin)
     .where(
@@ -145,14 +160,20 @@ export async function resolverSalidasCalibre(
     const etiqueta = formatCalibre(row.calibreFrom, row.calibreTo);
     if (!etiqueta) continue;
     huboDeclaracion = true;
+    const calibre = {
+      etiqueta,
+      bins: row.bins == null ? null : Number(row.bins),
+    };
     const actual = resultado.get(clave);
     if (actual) {
-      if (!actual.calibres.includes(etiqueta)) actual.calibres.push(etiqueta);
+      if (!actual.calibres.some((c) => c.etiqueta === etiqueta)) {
+        actual.calibres.push(calibre);
+      }
     } else {
       resultado.set(clave, {
         salidaOrden: null,
         salidaNombre: null,
-        calibres: [etiqueta],
+        calibres: [calibre],
       });
     }
   }
@@ -169,7 +190,9 @@ export async function resolverSalidasCalibre(
   if (huboDeclaracion) {
     for (const entrada of resultado.values()) {
       if (entrada.calibres.length === 0) {
-        entrada.calibres.push(ETIQUETA_MERMA);
+        // Sin bins: la merma no se declara, se deduce de la ausencia de calibre,
+        // asi que no hay ningun numero de bins que mostrar.
+        entrada.calibres.push({ etiqueta: ETIQUETA_MERMA, bins: null });
       }
     }
   }

--- a/my-project/src/lib/salida-calibre.ts
+++ b/my-project/src/lib/salida-calibre.ts
@@ -20,6 +20,18 @@ export interface CalibreDeclarado {
   bins: number | null;
 }
 
+/**
+ * True si lo que salió por acá es merma. Cubre los dos casos que la producen:
+ * el rango abierto (no cierran el calibre) y la salida que no declaró nada en un
+ * lote que sí tuvo cierre.
+ *
+ * Se marca en el dato y no se deduce del texto en la UI, para que el criterio
+ * viva en un solo lugar.
+ */
+export function esMerma(calibres: CalibreDeclarado[]): boolean {
+  return calibres.some((c) => c.etiqueta.startsWith(ETIQUETA_MERMA));
+}
+
 export interface SalidaCalibre {
   salidaOrden: number | null;
   salidaNombre: string | null;


### PR DESCRIPTION
Continúa #82. Ahí quedó el calibre de cada salida; esto agrega los contenedores de entrada y salida, y saca la merma de los totales.

## Qué cambia

**1. Cajas de entrada y bins de salida del lote**

En la tarjeta "Resumen de dispositivos": `Entraron: 96 cajas` · `Salieron: 62 bins` · `Total: 1.162.040 bulbos`.

No son dos nombres de lo mismo — son dos tablas distintas:

| | Tabla | Qué es |
|---|---|---|
| **Entrada** | `caja` + `caja_lote_session` | El contenedor con QR asignado a la sesión de lote |
| **Salida** | `lote_cierre_calibre_bin.bins` | Los bins que se declaran por calibre al cerrar |

Va a nivel de lote y no por salida porque **una misma caja se asigna a todas las salidas a la vez** (96 cajas × 4 equipos = 408 asignaciones en un lote real): su producto se reparte entre ellas, así que por fila saldría el mismo número repetido.

**2. Bins por rango de calibre en la tabla**

El badge daba el total pero no de qué calibre era. Ahora cada fila trae sus bins, y como la fila ya identifica el rango, eso responde cuántos bins salieron en cada calibre. Va por fila y no agrupado porque **dentro de un lote cada calibre pertenece a una sola salida** (34/34 casos reales).

**3. La merma no se suma al total, ni en la página ni en el correo**

En `110.25.V4` el total mostraba 1.261.762 bulbos, de los cuales 99.722 (7,9%) eran merma. Ahora muestra 1.162.040 y la merma queda en su fila.

En el reporte la merma caía dentro de "Sin declarar", que mezclaba tres situaciones —lote sin cerrar, salida sin usar, y merma— y por eso no se podía filtrar. El criterio que las separa: **una salida que nunca declaró en ese lote sacó merma; una que sí declaró y tiene unidades fuera de sus rangos es producto pendiente de declarar.** Es el mismo criterio que usa la tabla, así que los dos números ahora coinciden: `110.25.V4` da calibrado 1.162.040 + merma 99.722 en pantalla y en el correo.

## Decisiones que vale la pena revisar

**Sin umbral de cantidad para distinguir "salida no usada" de merma.** Un lote chico puede tener valores bajos legítimos, y un conteo bajo sospechoso conviene contarlo como merma igual. Decisión explícita del dueño del dominio.

**Cajas distintas, no asignaciones.** Se reutiliza `getCajaCountForLote`, la misma definición que ya usa la tablet. En un lote real hay 102 asignaciones contra 96 cajas distintas (6 re-escaneadas).

**La etiqueta dice "Bulbos procesados" aunque el número excluya la merma.** Es preferencia del cliente; queda anotado en el código, y lo que evita leerlo como el total de la línea es la cifra de merma inmediatamente al lado.

**Endpoint propio** (`/api/lotes/[loteId]/contenedores`) en vez de agregar campos a `/api/lotes/summary`: esa ruta devuelve un array de dispositivos y la consumen dos vistas.

**`esMerma` lo marca el backend.** La UI no reconoce la merma por el texto de la etiqueta; el criterio vive en un solo lugar y cubre los dos casos que la producen (rango abierto y salida sin declarar en un lote con cierre).

## Efectos secundarios a tener en cuenta

- **Los porcentajes por calibre del reporte ahora son sobre producto calibrado**, no diluidos por el descarte.
- El total del lote en la app bajó para los lotes con merma. Es intencional.

## Verificación

- `tsc --noEmit` limpio.
- Endpoint contra datos reales: `110.25.V4` → `{cajasEntrada: 96, binsSalida: 62}`; bins por fila 23/19/20, que suman los 62 del badge.
- Página revisada en pantalla en cada paso.
- Reporte generado contra la base y correo de prueba enviado y recibido, incluyendo un lote con merma.

### Bugs encontrados y corregidos durante el desarrollo

- La "Salida 2" de un servicio se filtraba a lotes de **otro** servicio sin salidas configuradas: se resolvía por dispositivo en vez de por par (dispositivo, servicio).
- Al pasar `calibres` de `string[]` a `{ etiqueta, bins }[]`, **`tsc` no marcó los puntos de render**: `join()` sobre objetos compila igual y muestra `[object Object]`. Se corrigieron los cuatro consumidores a mano.
- La merma quedaba solo a nivel de servicio: el detalle por lote del Excel y el PDF escondía el descarte.
- Un lote que **solo** saca merma aparecía como "Sin datos para el periodo". Se detectó porque un dry run mostró 3 lotes con merma y el Excel traía 2 filas.

### Sin cubrir
- La etiqueta de merma por **rango abierto** no se pudo probar end-to-end: no existe en la base ningún lote con conteos y rango abierto a la vez. Los 6 casos de rango abierto tienen 0 bulbos y 0 bins, en lotes vacíos o de prueba. Las ramas de `formatCalibre` se verificaron aisladas.
- Los contenedores solo se agregaron a `/app/servicios/[id]/lotes/[id]`, la vista que se usa a diario. La otra página de lote no los muestra; el endpoint ya está listo para que los consuma.
- Para un lote antiguo, las salidas en cero se listan según la configuración **actual** del calibrador.

### No relacionado
`/api/calibres/breakdown` devuelve **500** — `FULL JOIN is only supported with merge-joinable or hash-joinable join conditions` sobre la vista `v_lote_calibre_declarado` (`calibre-resolver.ts:81`). La pestaña **Calibres** está rota. Preexistente, no se toca acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
