### PR TITLE
fix(lotes): acotar el resumen del lote al servicio de la vista

### DIFF
--- a/my-project/src/app/api/lotes/summary/route.ts
+++ b/my-project/src/app/api/lotes/summary/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { loteTotalStats, dispositivo } from "@/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   claveParDispositivoServicio,
   compararPorSalida,
@@ -18,6 +18,16 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "loteId is required" }, { status: 400 });
   }
 
+  // Un lote pasa por varios servicios (prechequeo, lavado, calibrado) y el mismo
+  // equipo cuenta en más de uno, con salida configurada solo en algunos. Sin
+  // acotar el servicio, la tabla mostraba el mismo calibrador dos veces — una
+  // como "Salida 3" (vínculo vigente) y otra como "ORIN-AGX-1" (etapa anterior,
+  // sin salida) — y sumaba conteos de meses distintos en el total del lote.
+  //
+  // La página de servicio manda su servicioId; la vista de lote sin servicio no
+  // lo manda y sigue viendo el lote completo.
+  const servicioId = searchParams.get("servicioId");
+
   const rows = await db
     .select({
       dispositivoId: loteTotalStats.dispositivoId,
@@ -29,7 +39,14 @@ export async function GET(request: Request) {
     })
     .from(loteTotalStats)
     .innerJoin(dispositivo, eq(dispositivo.id, loteTotalStats.dispositivoId))
-    .where(eq(loteTotalStats.loteId, loteId))
+    .where(
+      servicioId
+        ? and(
+            eq(loteTotalStats.loteId, loteId),
+            eq(loteTotalStats.servicioId, servicioId)
+          )
+        : eq(loteTotalStats.loteId, loteId)
+    )
     .groupBy(
       loteTotalStats.dispositivoId,
       dispositivo.nombre,
@@ -76,7 +93,12 @@ export async function GET(request: Request) {
   const yaListados = new Set(
     rows.map((r) => claveParDispositivoServicio(r.dispositivoId, r.servicioId))
   );
-  const servicioIds = [...new Set(rows.map((r) => r.servicioId))];
+  // Con servicio fijo se parte de él y no de las filas: si ninguna salida contó
+  // en este lote no hay filas de dónde deducirlo, y son justo los casos donde
+  // interesa listarlas en 0.
+  const servicioIds = servicioId
+    ? [servicioId]
+    : [...new Set(rows.map((r) => r.servicioId))];
   const enCero = (await salidasConfiguradas(servicioIds))
     .filter(
       (s) =>

--- a/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
+++ b/my-project/src/app/app/servicios/[servicioId]/lotes/[loteId]/page.tsx
@@ -177,10 +177,13 @@ export default function LoteDetailPage() {
   }, [servicioId, loteId]);
 
   // ── Fetch resumen ──────────────────────────────────────────────────────────
+  // Se pasa el servicioId: esta vista es del lote DENTRO de este servicio, así
+  // que las salidas y los conteos son los de esta etapa. Sin el filtro salían
+  // también los del prechequeo u otra etapa previa del mismo lote.
   useEffect(() => {
-    if (!loteId) return;
+    if (!servicioId || !loteId) return;
     setSummaryLoading(true);
-    fetch(`/api/lotes/summary?loteId=${loteId}`)
+    fetch(`/api/lotes/summary?loteId=${loteId}&servicioId=${servicioId}`)
       .then(async (res) => {
         if (!res.ok) throw new Error("Error al cargar resumen");
         const data: DeviceSummary[] = await res.json();
@@ -188,7 +191,7 @@ export default function LoteDetailPage() {
       })
       .catch(console.error)
       .finally(() => setSummaryLoading(false));
-  }, [loteId]);
+  }, [servicioId, loteId]);
 
   // ── Fetch contenedores (cajas de entrada / bins de salida) ─────────────────
   useEffect(() => {


### PR DESCRIPTION
## Problema

En `/app/servicios/[servicioId]/lotes/[loteId]` el mismo calibrador aparecía dos veces en la tabla de salidas: una como **"Salida 3"** y otra como **"ORIN-AGX-1"**, con valores distintos.

No eran datos duplicados. `ORIN-AGX-1` tiene dos vínculos en `dispositivo_servicio`:

| Servicio | salida | vínculo |
|---|---|---|
| Planting Stock Pelú | 3 — "Salida 3" | vigente |
| Prechequeo Planting Stock Pelú 2026 | sin configurar | terminado 2026-07-22 |

Los lotes recientes pasaron por las dos etapas, y la página pedía `/api/lotes/summary` **sin** `servicioId` (a diferencia del resto de sus fetch), así que traía las filas de ambas. La del prechequeo, sin salida configurada, cae al nombre del equipo por la convención de `salidaLabel`.

En el lote `2075.25.V5` eso mostraba una fila extra de 35.375 / 7 con último dato del 18 de mayo, y esos bulbos entraban al total del lote junto a los del calibrado de agosto.

## Cambio

- `/api/lotes/summary` acepta `servicioId` opcional y filtra `lote_total_stats` por él.
- Las salidas en 0 se resuelven contra ese servicio en vez de deducirse de las filas, para que se listen aunque ninguna haya contado en el lote.
- La página de servicio manda su `servicioId`. `SummaryLote` (vista de lote sin servicio) no lo manda y sigue viendo el lote completo.

`/api/lotes/[loteId]/detail` no estaba afectado: agrupa por dispositivo y ya elegía un solo vínculo por equipo.

## Verificación

- `npx tsc --noEmit` sin errores.
- Consulta directa a la base sobre el lote del reporte: con el filtro quedan las 4 filas de Planting Stock Pelú (Salida 2, Salida 3, THOR-1, ORIN-NANO-1) y desaparece la del prechequeo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)